### PR TITLE
Workaround for netcdfConfig packaged by conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -197,7 +197,7 @@ deploy:
   strategy: git
   local_dir: build/docs/html
   skip_cleanup: true
-  github-token: $GITHUB_TOKEN
+  token: $GITHUB_TOKEN
   keep_history: false
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -186,7 +186,7 @@ script:
 after_success:
   - if [[ $BUILD_DOCS == 1 ]]; then
       cmake ..;
-      make mem3dg_docs;
+      ninja mem3dg_docs;
     fi;
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+arch: amd64
+os: linux
+dist: focal
+
 notifications:
   email: false
   slack:
@@ -18,7 +22,7 @@ branches:
   - master
 
 # BUILD MATRIX
-matrix:
+jobs:
   fast_finish: true
   
   # allow_failures:
@@ -190,10 +194,11 @@ after_success:
     fi;
 deploy:
   provider: pages
-  local-dir: build/docs/html
-  skip-cleanup: true
+  strategy: git
+  local_dir: build/docs/html
+  skip_cleanup: true
   github-token: $GITHUB_TOKEN
-  keep-history: false
+  keep_history: false
   on:
     branch: master
     condition: $BUILD_DOCS == 1

--- a/cmake/FindnetCDF.cmake
+++ b/cmake/FindnetCDF.cmake
@@ -23,10 +23,11 @@ if (netCDF_FOUND)
 
       # temporary hack to workaround netcdf packaging in conda
       get_target_property(_libs netCDF::netcdf INTERFACE_LINK_LIBRARIES)
-      list(FILTER _libs EXCLUDE REGEX ".*/x86_64-conda_cos6-linux-gnu/.*")
-      set_target_properties(netCDF::netcdf PROPERTIES INTERFACE_LINK_LIBRARIES "${_libs}")
-
-
+      if(${_libs})
+        list(FILTER _libs EXCLUDE REGEX ".*/x86_64-conda_cos6-linux-gnu/.*")
+        set_target_properties(netCDF::netcdf PROPERTIES INTERFACE_LINK_LIBRARIES "${_libs}")
+      endif ()
+      
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "netCDF::netcdf")
     elseif (TARGET "netcdf")

--- a/cmake/FindnetCDF.cmake
+++ b/cmake/FindnetCDF.cmake
@@ -23,7 +23,7 @@ if (netCDF_FOUND)
 
       # temporary hack to workaround netcdf packaging in conda
       get_target_property(_libs netCDF::netcdf INTERFACE_LINK_LIBRARIES)
-      if(${_libs})
+      if(_libs)
         list(FILTER _libs EXCLUDE REGEX ".*/x86_64-conda_cos6-linux-gnu/.*")
         set_target_properties(netCDF::netcdf PROPERTIES INTERFACE_LINK_LIBRARIES "${_libs}")
       endif ()

--- a/cmake/FindnetCDF.cmake
+++ b/cmake/FindnetCDF.cmake
@@ -33,7 +33,6 @@ if (netCDF_FOUND)
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "netcdf")
     else ()
-      list(FILTER ${netCDF_LIBRARIES} EXCLUDE REGEX "$ENV{BUILD_PREFIX}")
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "${netCDF_LIBRARIES}")
     endif ()

--- a/cmake/FindnetCDF.cmake
+++ b/cmake/FindnetCDF.cmake
@@ -20,12 +20,20 @@ if (netCDF_FOUND)
     add_library(NetCDF::NetCDF INTERFACE IMPORTED)
     if (TARGET "netCDF::netcdf")
       # 4.7.3
+
+      # temporary hack to workaround netcdf packaging in conda
+      get_target_property(_libs netCDF::netcdf INTERFACE_LINK_LIBRARIES)
+      list(FILTER _libs EXCLUDE REGEX ".*/x86_64-conda_cos6-linux-gnu/.*")
+      set_target_properties(netCDF::netcdf PROPERTIES INTERFACE_LINK_LIBRARIES "${_libs}")
+
+
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "netCDF::netcdf")
     elseif (TARGET "netcdf")
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "netcdf")
     else ()
+      list(FILTER ${netCDF_LIBRARIES} EXCLUDE REGEX "$ENV{BUILD_PREFIX}")
       set_target_properties(NetCDF::NetCDF PROPERTIES
         INTERFACE_LINK_LIBRARIES "${netCDF_LIBRARIES}")
     endif ()

--- a/setup.py
+++ b/setup.py
@@ -116,10 +116,8 @@ setup(
     classifiers=[c for c in CLASSIFIERS.split('\n') if c],
     keywords='meshing',
     cmake_args=cmake_args,
-    setup_requires=["setuptools", "wheel", "scikit-build", "pytest-runner", "cmake"],
     install_requires=[],
     extras_require={
-        # "docs" : docs_require,
         "test" : tests_require,
     },
     zip_safe=False,


### PR DESCRIPTION
CMake filters out extra linked libraries which break configuration.