### PR TITLE
Streamline dependencies

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# How to contribute
+
+We welcome contributions from external contributors, and this document
+describes how to merge code changes into `Mem3dg`.
+
+## Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free).
+* [Fork](https://help.github.com/articles/fork-a-repo/) this repository on GitHub.
+* On your local machine,
+  [clone](https://help.github.com/articles/cloning-a-repository/) your fork of
+  the repository.
+
+## Making Changes
+
+* Add some really awesome code to your local fork.  It's usually a [good
+  idea](http://blog.jasonmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)
+  to make changes on a
+  [branch](https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/)
+  with the branch name relating to the feature you are going to add.
+* When you are ready for others to examine and comment on your new feature,
+  navigate to your fork of `Mem3dg` on GitHub and open a [pull
+  request](https://help.github.com/articles/using-pull-requests/) (PR). Note that
+  after you launch a PR from one of your fork's branches, all
+  subsequent commits to that branch will be added to the open pull request
+  automatically.  Each commit added to the PR will be validated for
+  mergability, compilation and test suite compliance; the results of these tests
+  will be visible on the PR page.
+* If you're providing a new feature, you must add test cases and documentation.
+* When the code is ready to go, make sure you run the test suite using pytest.
+* When you're ready to be considered for merging, check the "Ready to go"
+  box on the PR page to let the Mem3dg devs know that the changes are complete.
+  The code will not be merged until this box is checked, the continuous
+  integration returns checkmarks,
+  and multiple core developers give "Approved" reviews.
+
+# Additional Resources
+
+* [General GitHub documentation](https://help.github.com/)
+* [PR best practices](http://codeinthehole.com/writing/pull-requests-and-other-good-practices-for-teams-using-github/)
+* [A guide to contributing to software packages](http://www.contribution-guide.org)
+* [Thinkful PR example](http://www.thinkful.com/learn/github-pull-request-tutorial/#Time-to-Submit-Your-First-PR)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Description
+Provide a brief description of the PR's purpose here.
+
+## Todos
+Notable points that this PR has either accomplished or will accomplish.
+  - [ ] TODO 1
+
+## Questions
+- [ ] Question1
+
+## Status
+- [ ] Ready to go

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -24,7 +24,7 @@ if(M3DG_GET_OWN_EIGEN)
   FetchContent_Declare(
     eigen
     GIT_REPOSITORY  https://gitlab.com/libeigen/eigen.git
-    GIT_TAG         3.3.7
+    GIT_TAG         3.3.9
     GIT_SHALLOW     TRUE
     SOURCE_DIR      "${CMAKE_CURRENT_BINARY_DIR}/eigen-src"
     BINARY_DIR      "${CMAKE_CURRENT_BINARY_DIR}/eigen-build"
@@ -91,4 +91,16 @@ if(BUILD_PYMEM3DG)
   # endif()
 endif()
 
-add_subdirectory(libigl)
+
+# ############################################################################
+# Configure libigl
+# ############################################################################
+
+# CMakeList in root is for testing and enables things we don't need
+# We can restore this in libigl v3.0.0 when conventional behavior is restored.
+
+# add_subdirectory(libigl)
+
+# Until then we can configure with this module
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/libigl/cmake")
+include(${CMAKE_CURRENT_SOURCE_DIR}/libigl/cmake/libigl.cmake)

--- a/pymem3dg/CMakeLists.txt
+++ b/pymem3dg/CMakeLists.txt
@@ -21,7 +21,7 @@ if(M3DG_GET_OWN_PYBIND11)
   FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG v2.5.0
+    GIT_TAG v2.6.2
     GIT_SHALLOW TRUE
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/pybind11-src" BINARY_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/pybind11-build"

--- a/pymem3dg/src/mem3dg.cpp
+++ b/pymem3dg/src/mem3dg.cpp
@@ -36,7 +36,7 @@
 #include "mem3dg/solver/typetraits.h"
 #include "mem3dg/solver/util.h"
 
-#include <pybind11/embed.h>
+// #include <pybind11/embed.h>
 
 #include "igl/loop.h"
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,25 +17,14 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.10.0
+  GIT_TAG origin/master
   GIT_SHALLOW TRUE
   SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-src" 
   BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
 )
 # Prevent overriding the parent project's compiler/linker settings on Windows
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-  FetchContent_Populate(googletest)
-  # Add googletest directly to our build. This defines the gtest and gtest_main
-  # targets.
-  add_subdirectory(
-    ${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL
-  )
-endif()
-
-set_property(TARGET gtest PROPERTY CXX_STANDARD 11)
+FetchContent_MakeAvailable(googletest)
 
 # Build the tests
 set(TEST_SRCS src/main_test.cpp src/dotproduct_test.cpp
@@ -52,9 +41,9 @@ add_test(NAME Mem3DG_Main_Tests COMMAND Mem3DG-tests)
 # Main DDG target
 # ##############################################################################
 add_executable(ddg scratch.cpp) 
-target_link_libraries(ddg PRIVATE mem3dg polyscope igl::core) 
+target_link_libraries(ddg PRIVATE mem3dg) 
 set_target_properties(ddg PROPERTIES CXX_VISIBILITY_PRESET hidden)
 
 add_executable(ddg_patch scratch_patch.cpp) 
-target_link_libraries(ddg_patch PRIVATE mem3dg polyscope igl::core) 
+target_link_libraries(ddg_patch PRIVATE mem3dg) 
 set_target_properties(ddg_patch PROPERTIES CXX_VISIBILITY_PRESET hidden)


### PR DESCRIPTION
## Description
Streamlining the fetching and building of the dependencies

## Todos
  - [x] Bump pybind11 to 2.6.2
  - [x] Bump eigen to 3.3.9
  - [x] Stop libigl from building its external dependencies
  - [x] Add github pull request template

## Status
- [x] Ready to go
