### PR TITLE
Switching to standard Helfrich

### DIFF
--- a/include/mem3dg/macros.h
+++ b/include/mem3dg/macros.h
@@ -174,7 +174,7 @@ namespace detail {
  * @param t object to print
  */
 template <typename T> void mem3dg_print(std::ostringstream &ss, T &&t) {
-  ss << std::forward<T>(t) << " ";
+  ss << std::forward<T>(t);
 }
 
 /**
@@ -191,6 +191,32 @@ void mem3dg_print(std::ostringstream &ss, T &&t, TS &&...ts) {
   ss << std::forward<T>(t) << " ";
   mem3dg_print(ss, std::forward<TS>(ts)...);
 }
+
+/**
+ * @brief Terminating case of helpful print
+ *
+ * @tparam T typename of argument to print
+ * @param ss reference to active ostringstream
+ * @param t object to print
+ */
+template <typename T> void mem3dg_print_nospace(std::ostringstream &ss, T &&t) {
+  ss << std::forward<T>(t);
+}
+
+/**
+ * @brief Recursive condition of helpful print
+ *
+ * @tparam T typename of current argument
+ * @tparam TS pack of subsequent types
+ * @param ss reference to active ostringstream
+ * @param t current object to output
+ * @param ts pack of following objects
+ */
+template <typename T, typename... TS>
+void mem3dg_print_nospace(std::ostringstream &ss, T &&t, TS &&...ts) {
+  ss << std::forward<T>(t);
+  mem3dg_print_nospace(ss, std::forward<TS>(ts)...);
+}
 } // namespace detail
 
 /**
@@ -204,6 +230,32 @@ template <typename... TS> void mem3dg_print(TS &&...ts) {
   std::ostringstream ss;
   detail::mem3dg_print(ss, std::forward<TS>(ts)...);
   std::cout << ss.str() << std::endl;
+}
+
+/**
+ * @brief A helpful print function which auto adds spaces between objects, but
+ * no final endl.
+ *
+ * @tparam TS pack of types for objects to print
+ * @param ts pack of objects
+ */
+template <typename... TS> void mem3dg_print_noendl(TS &&...ts) {
+  std::ostringstream ss;
+  detail::mem3dg_print(ss, std::forward<TS>(ts)...);
+  std::cout << ss.str();
+}
+
+/**
+ * @brief A helpful print function which prints
+ * objects.
+ *
+ * @tparam TS pack of types for objects to print
+ * @param ts pack of objects
+ */
+template <typename... TS> void mem3dg_print_nospace(TS &&...ts) {
+  std::ostringstream ss;
+  detail::mem3dg_print_nospace(ss, std::forward<TS>(ts)...);
+  std::cout << ss.str();
 }
 
 /**

--- a/include/mem3dg/solver/forces.h
+++ b/include/mem3dg/solver/forces.h
@@ -58,6 +58,8 @@ struct Forces {
 
   /// Cached spontaneous curvature force
   gcs::VertexData<double> spontaneousCurvatureForce;
+  /// Cached gaussian curvature force
+  gcs::VertexData<double> gaussianCurvatureForce;
   /// Cached deviatoric force
   gcs::VertexData<double> deviatoricCurvatureForce;
   /// Cached area difference force
@@ -95,6 +97,8 @@ struct Forces {
   gcs::VertexData<gc::Vector3> spontaneousCurvatureForceVec_gaussVec;
   /// Cached spontaneous curvature force schlafliVec component
   gcs::VertexData<gc::Vector3> spontaneousCurvatureForceVec_schlafliVec;
+  /// Cached Gaussian curvature force vector
+  gcs::VertexData<gc::Vector3> gaussianCurvatureForceVec;
 
   /// Cached deviatoric curvature force
   gcs::VertexData<gc::Vector3> deviatoricCurvatureForceVec;
@@ -142,6 +146,8 @@ struct Forces {
   gcs::VertexData<double> interiorPenaltyPotential;
   /// Cached spontaneous curvature related chemical potential
   gcs::VertexData<double> spontaneousCurvaturePotential;
+  /// Cached Gaussian curvature related chemical potential
+  gcs::VertexData<double> gaussianCurvaturePotential;
   /// Cached deviatoric curvature related chemical potential
   gcs::VertexData<double> deviatoricCurvaturePotential;
   /// Cached adsorption related chemical potential
@@ -165,17 +171,18 @@ struct Forces {
 
   Forces(gcs::ManifoldSurfaceMesh &mesh_, gcs::VertexPositionGeometry &vpg_)
       : mesh(mesh_), vpg(vpg_), spontaneousCurvatureForce(mesh, 0),
-        deviatoricCurvatureForce(mesh, 0), areaDifferenceForce(mesh, 0),
-        osmoticForce(mesh, 0), capillaryForce(mesh, 0),
-        lineCapillaryForce(mesh, 0), adsorptionForce(mesh, 0),
-        aggregationForce(mesh, 0), entropyForce(mesh, 0),
-        externalForce(mesh, 0), selfAvoidanceForce(mesh, 0),
-        mechanicalForce(mesh, 0), conservativeForce(mesh, 0),
-        osmoticPressure(0), surfaceTension(0),
+        gaussianCurvatureForce(mesh, 0), deviatoricCurvatureForce(mesh, 0),
+        areaDifferenceForce(mesh, 0), osmoticForce(mesh, 0),
+        capillaryForce(mesh, 0), lineCapillaryForce(mesh, 0),
+        adsorptionForce(mesh, 0), aggregationForce(mesh, 0),
+        entropyForce(mesh, 0), externalForce(mesh, 0),
+        selfAvoidanceForce(mesh, 0), mechanicalForce(mesh, 0),
+        conservativeForce(mesh, 0), osmoticPressure(0), surfaceTension(0),
         spontaneousCurvatureForceVec(mesh, {0, 0, 0}),
         spontaneousCurvatureForceVec_areaGrad(mesh, {0, 0, 0}),
         spontaneousCurvatureForceVec_gaussVec(mesh, {0, 0, 0}),
         spontaneousCurvatureForceVec_schlafliVec(mesh, {0, 0, 0}),
+        gaussianCurvatureForceVec(mesh, {0, 0, 0}),
         deviatoricCurvatureForceVec(mesh, {0, 0, 0}),
         deviatoricCurvatureForceVec_mean(mesh, {0, 0, 0}),
         deviatoricCurvatureForceVec_gauss(mesh, {0, 0, 0}),
@@ -193,6 +200,7 @@ struct Forces {
         faceSpringForceVec(mesh, {0, 0, 0}), lcrSpringForceVec(mesh, {0, 0, 0}),
         interiorPenaltyPotential(mesh, 0),
         spontaneousCurvaturePotential(mesh, 0),
+        gaussianCurvaturePotential(mesh, 0),
         deviatoricCurvaturePotential(mesh, 0), adsorptionPotential(mesh, 0),
         dirichletPotential(mesh, 0), aggregationPotential(mesh, 0),
         entropyPotential(mesh, 0), chemicalPotential(mesh, 0),

--- a/include/mem3dg/solver/parameters.h
+++ b/include/mem3dg/solver/parameters.h
@@ -63,6 +63,11 @@ struct Parameters {
     /// preferred area difference
     double dA0 = 0;
 
+    /// Gaussian modulus
+    double Kg = 0;
+    /// Constant of gaussian modulus vs protein density
+    double Kgc = 0;
+
     /// Deviatoric modulus
     double Kd = 0;
     /// Constant of deviatoric modulus vs protein density

--- a/include/mem3dg/solver/parameters.h
+++ b/include/mem3dg/solver/parameters.h
@@ -47,9 +47,6 @@
 #include "mem3dg/solver/mesh_process.h"
 #include "mem3dg/type_utilities.h"
 
-namespace gc = ::geometrycentral;
-namespace gcs = ::geometrycentral::surface;
-
 namespace mem3dg {
 
 namespace solver {
@@ -187,7 +184,7 @@ struct Parameters {
   struct Protein {
     /// interior point parameter for protein density
     double proteinInteriorPenalty = 0; // 1e-6
-    /// precription of protein density
+    /// prescription of protein density
     std::function<EigenVectorX1d(double, EigenVectorX1d, EigenVectorX1d)>
         prescribeProteinDensityDistribution = NULL;
     /// period of updating protein density distribution

--- a/include/mem3dg/solver/system.h
+++ b/include/mem3dg/solver/system.h
@@ -75,6 +75,8 @@ struct Energy {
   double potentialEnergy = 0;
   /// spontaneous curvature energy of the membrane
   double spontaneousCurvatureEnergy = 0;
+  /// Gaussian curvature energy
+  double gaussianCurvatureEnergy = 0;
   /// deviatoric curvature energy of the membrane
   double deviatoricCurvatureEnergy = 0;
   /// area difference energy of the membrane
@@ -143,6 +145,8 @@ public:
   gcs::VertexData<double> Kb;
   /// deviatoric rigidity of the membrane
   gcs::VertexData<double> Kd;
+  /// gaussian modulus of the membrane
+  gcs::VertexData<double> Kg;
   /// is Smooth
   bool isSmooth;
   /// if being mutated
@@ -253,6 +257,7 @@ public:
     H0 = gcs::VertexData<double>(*geometry.mesh);
     Kb = gcs::VertexData<double>(*geometry.mesh);
     Kd = gcs::VertexData<double>(*geometry.mesh);
+    Kg = gcs::VertexData<double>(*geometry.mesh);
 
     chemErrorNorm = 0;
     mechErrorNorm = 0;
@@ -414,6 +419,11 @@ public:
    * @brief Compute spontaneous curvature energy
    */
   void computeSpontaneousCurvatureEnergy();
+
+  /**
+   * @brief Compute deviatoric curvature energy
+   */
+  void computeGaussianCurvatureEnergy();
 
   /**
    * @brief Compute deviatoric curvature energy

--- a/python_src/pymem3dg/boilerplate.py
+++ b/python_src/pymem3dg/boilerplate.py
@@ -149,7 +149,7 @@ def ambientSolutionOsmoticPressureModel(
     return (pressure, energy)
 
 
-def prescribeGeodesicPoteinDensityDistribution(
+def prescribeGeodesicProteinDensityDistribution(
     time: float,
     vertexMeanCuravtures: npt.NDArray[np.float64],
     geodesicDistance: npt.NDArray[np.float64],

--- a/python_src/pymem3dg_parameters.cpp
+++ b/python_src/pymem3dg_parameters.cpp
@@ -110,6 +110,14 @@ void init_parameters(py::module_ &pymem3dg) {
                         R"delim(
           get constant of deviatoric modulus vs protein density
       )delim");
+  bending.def_readwrite("Kg", &Parameters::Bending::Kg,
+                        R"delim(
+          get Gaussian rigidity of the membrane
+      )delim");
+  bending.def_readwrite("Kgc", &Parameters::Bending::Kgc,
+                        R"delim(
+          get constant of Gaussian modulus vs protein density
+      )delim");
   bending.def_readwrite("Kb", &Parameters::Bending::Kb,
                         R"delim(
           get Bending rigidity of the bare membrane

--- a/src/solver/energy.cpp
+++ b/src/solver/energy.cpp
@@ -41,26 +41,28 @@ void System::computeSpontaneousCurvatureEnergy() {
               geometry.vpg->vertexDualAreas.raw().array() -
           H0.raw().array());
   energy.spontaneousCurvatureEnergy =
-      (Kb.raw().array() * geometry.vpg->vertexDualAreas.raw().array() *
-       H_difference.array().square())
-          .sum();
+      2 * (Kb.raw().array() * geometry.vpg->vertexDualAreas.raw().array() *
+           H_difference.array().square())
+              .sum();
 
   // when considering topological changes, additional term of gauss curvature
   // E.BE = P.Kb * H_difference.transpose() * M * H_difference + P.KG * (M *
   // K).sum();
 }
 
+void System::computeGaussianCurvatureEnergy() {
+  energy.gaussianCurvatureEnergy =
+      (Kg.raw().array() * geometry.vpg->vertexGaussianCurvatures.raw().array())
+          .sum();
+}
+
 void System::computeDeviatoricCurvatureEnergy() {
   energy.deviatoricCurvatureEnergy =
       (Kd.raw().array() *
-       geometry.vpg->vertexGaussianCurvatures.raw().array().square() /
-       geometry.vpg->vertexDualAreas.raw().array())
+       (geometry.vpg->vertexMeanCurvatures.raw().array().square() /
+            geometry.vpg->vertexDualAreas.raw().array() -
+        geometry.vpg->vertexGaussianCurvatures.raw().array()))
           .sum();
-  // (Kd.raw().array() *
-  //  (geometry.vpg->vertexMeanCurvatures.raw().array().square() /
-  //       geometry.vpg->vertexDualAreas.raw().array() -
-  //   geometry.vpg->vertexGaussianCurvatures.raw().array()))
-  //     .sum();
 }
 
 void System::computeAreaDifferenceEnergy() {
@@ -283,6 +285,7 @@ double System::computePotentialEnergy() {
   energy.lcrSpringEnergy = 0;
 
   computeSpontaneousCurvatureEnergy();
+  computeGaussianCurvatureEnergy();
   computeDeviatoricCurvatureEnergy();
 
   // optional internal potential energy
@@ -323,10 +326,10 @@ double System::computePotentialEnergy() {
 
   // summerize internal potential energy
   energy.potentialEnergy =
-      energy.spontaneousCurvatureEnergy + energy.deviatoricCurvatureEnergy +
-      energy.areaDifferenceEnergy + energy.surfaceEnergy +
-      energy.pressureEnergy + energy.adsorptionEnergy + energy.dirichletEnergy +
-      energy.aggregationEnergy + energy.entropyEnergy +
+      energy.spontaneousCurvatureEnergy + energy.gaussianCurvatureEnergy +
+      energy.deviatoricCurvatureEnergy + energy.areaDifferenceEnergy +
+      energy.surfaceEnergy + energy.pressureEnergy + energy.adsorptionEnergy +
+      energy.dirichletEnergy + energy.aggregationEnergy + energy.entropyEnergy +
       energy.selfAvoidancePenalty + energy.proteinInteriorPenalty +
       energy.edgeSpringEnergy + energy.faceSpringEnergy +
       energy.lcrSpringEnergy;

--- a/src/solver/force.cpp
+++ b/src/solver/force.cpp
@@ -53,6 +53,7 @@ void System::computeGeometricForces(size_t i) {
   gc::Vector3 spontaneousCurvatureForceVec_areaGrad{0, 0, 0};
   gc::Vector3 spontaneousCurvatureForceVec_gaussVec{0, 0, 0};
   gc::Vector3 spontaneousCurvatureForceVec_schlafliVec{0, 0, 0};
+  gc::Vector3 gaussianCurvatureForceVec{0, 0, 0};
   gc::Vector3 deviatoricCurvatureForceVec{0, 0, 0};
   gc::Vector3 deviatoricCurvatureForceVec_mean{0, 0, 0};
   gc::Vector3 deviatoricCurvatureForceVec_gauss{0, 0, 0};
@@ -65,16 +66,14 @@ void System::computeGeometricForces(size_t i) {
   gc::Vector3 entropyForceVec{0, 0, 0};
   double Ai = geometry.vpg->vertexDualAreas[i];
   double Hi = geometry.vpg->vertexMeanCurvatures[i] / Ai;
-  double KGi = geometry.vpg->vertexGaussianCurvatures[i] / Ai;
   double H0i = H0[i];
   double Kbi = Kb[i];
+  double Kgi = Kg[i];
   double Kdi = Kd[i];
   double proteinDensityi = proteinDensity[i];
   double areaDifferenceK =
       0.25 * parameters.bending.alpha * parameters.bending.Kb * constants::PI;
   double totalMeanCurvature = geometry.vpg->vertexMeanCurvatures.raw().sum();
-
-  bool boundaryVertex = v.isBoundary();
 
   for (gc::Halfedge he : v.outgoingHalfedges()) {
     std::size_t fID = he.face().getIndex();
@@ -86,14 +85,13 @@ void System::computeGeometricForces(size_t i) {
                                          : gc::Vector3{0, 0, 0}};
     double Aj = geometry.vpg->vertexDualAreas[i_vj];
     double Hj = geometry.vpg->vertexMeanCurvatures[i_vj] / Aj;
-    double KGj = geometry.vpg->vertexGaussianCurvatures[i_vj] / Aj;
     double H0j = H0[i_vj];
     double Kbj = Kb[i_vj];
+    double Kgj = Kg[i_vj];
     double Kdj = Kd[i_vj];
     double proteinDensityj = proteinDensity[i_vj];
     bool interiorHalfedge = he.isInterior();
     // bool boundaryEdge = he.edge().isBoundary();
-    bool boundaryNeighborVertex = he.next().vertex().isBoundary();
 
     // compute fundamental variational vectors
     gc::Vector3 areaGrad =
@@ -124,11 +122,14 @@ void System::computeGeometricForces(size_t i) {
                   proteinDensity, he) /
                   geometry.vpg->faceAreas[fID]
             : gc::Vector3{0.0, 0.0, 0.0};
+
+    //  bool boundaryVertex = v.isBoundary();
     gc::Vector3 gaussVarVec1 =
-        boundaryVertex ? gc::Vector3{0.0, 0.0, 0.0}
+        v.isBoundary() ? gc::Vector3{0.0, 0.0, 0.0}
                        : -geometry.computeCornerAngleVariation(he, he.vertex());
+    //  bool boundaryNeighborVertex = he.next().vertex().isBoundary();
     gc::Vector3 gaussVarVec2 =
-        boundaryNeighborVertex
+        he.next().vertex().isBoundary()
             ? gc::Vector3{0.0, 0.0, 0.0}
             : -geometry.computeCornerAngleVariation(he.next(), he.vertex()) -
                   geometry.computeCornerAngleVariation(he.twin(), he.vertex());
@@ -136,7 +137,7 @@ void System::computeGeometricForces(size_t i) {
     // Assemble to forces
     if (Kbi != 0 || Kbj != 0) { // spontaneous curvature force
       spontaneousCurvatureForceVec_schlafliVec -=
-          (Kbi * (Hi - H0i) * schlafliVec1 + Kbj * (Hj - H0j) * schlafliVec2);
+          Kbi * (Hi - H0i) * schlafliVec1 + Kbj * (Hj - H0j) * schlafliVec2;
       spontaneousCurvatureForceVec_areaGrad -=
           (Kbi * (H0i * H0i - Hi * Hi) / 3 +
            Kbj * (H0j * H0j - Hj * Hj) * 2 / 3) *
@@ -144,31 +145,38 @@ void System::computeGeometricForces(size_t i) {
       spontaneousCurvatureForceVec_gaussVec -=
           (Kbi * (Hi - H0i) + Kbj * (Hj - H0j)) * gaussVec;
     }
+
     if (forces.osmoticPressure != 0) // omostic force
       osmoticForceVec +=
           forces.osmoticPressure *
           geometry.computeHalfedgeVolumeVariationVector(*geometry.vpg, he);
+
     if (forces.surfaceTension != 0) // surface capillary force
       capillaryForceVec -= forces.surfaceTension * areaGrad;
-    if (Kdi != 0 || Kdj != 0) { // deviatoric curvature force
-      deviatoricCurvatureForceVec_gauss -=
-          2 * Kdi * KGi * gaussVarVec1 + 2 * Kdj * KGj * gaussVarVec2 -
-          (Kdi * KGi * KGi / 3 + Kdj * KGj * KGj * 2 / 3) * areaGrad;
-      // deviatoricCurvatureForceVec_mean -=
-      //     (Kdi * Hi + Kdj * Hj) * gaussVec +
-      //     (Kdi * (-Hi * Hi) / 3 + Kdj * (-Hj * Hj) * 2 / 3) * areaGrad +
-      //     (Kdi * Hi * schlafliVec1 + Kdj * Hj * schlafliVec2);
-      // deviatoricCurvatureForceVec_gauss +=
-      //     Kdi * gaussVarVec1 + Kdj * gaussVarVec2;
+
+    if (Kgi != 0 || Kgj != 0) { // gaussian curvature forces
+      gaussianCurvatureForceVec -= Kgi * gaussVarVec1 + Kgj * gaussVarVec2;
     }
+
+    if (Kdi != 0 || Kdj != 0) { // deviatoric curvature force
+      deviatoricCurvatureForceVec_mean -=
+          (Kdi * Hi + Kdj * Hj) * gaussVec +
+          (Kdi * (-Hi * Hi) / 3 + Kdj * (-Hj * Hj) * 2 / 3) * areaGrad +
+          (Kdi * Hi * schlafliVec1 + Kdj * Hj * schlafliVec2);
+      deviatoricCurvatureForceVec_gauss +=
+          Kdi * gaussVarVec1 + Kdj * gaussVarVec2;
+    }
+
     if (parameters.adsorption.epsilon != 0) // adsorption force
       adsorptionForceVec -= (proteinDensityi / 3 + proteinDensityj * 2 / 3) *
                             parameters.adsorption.epsilon * areaGrad;
+
     if (parameters.aggregation.chi != 0) // aggregation force
       aggregationForceVec -=
           (pow(pow(2 * proteinDensityi - 1, 2) - 1, 2) / 3 +
            pow(pow(2 * proteinDensityj - 1, 2) - 1, 2) * 2 / 3) *
           parameters.aggregation.chi * areaGrad;
+
     if (parameters.entropy.xi != 0) // entropy force
       entropyForceVec -= ((proteinDensityi * log(proteinDensityi) +
                            (1 - proteinDensityi) * log(1 - proteinDensityi)) /
@@ -177,10 +185,12 @@ void System::computeGeometricForces(size_t i) {
                            (1 - proteinDensityj) * log(1 - proteinDensityj)) *
                               2 / 3) *
                          parameters.entropy.xi * areaGrad;
+
     if (parameters.dirichlet.eta != 0) // line capillary force
       lineCapillaryForceVec -=
           parameters.dirichlet.eta *
           (0.125 * dirichletVec - 0.5 * dphi_ijk.norm2() * oneSidedAreaGrad);
+
     if (parameters.bending.alpha != 0) // area difference force
       areaDifferenceForceVec -=
           4 * areaDifferenceK *
@@ -196,6 +206,9 @@ void System::computeGeometricForces(size_t i) {
               parameters.bending.D / parameters.bending.D /
               geometry.surfaceArea / geometry.surfaceArea * areaGrad;
   }
+  spontaneousCurvatureForceVec_areaGrad *= 2;
+  spontaneousCurvatureForceVec_gaussVec *= 2;
+  spontaneousCurvatureForceVec_schlafliVec *= 2;
 
   spontaneousCurvatureForceVec = spontaneousCurvatureForceVec_areaGrad +
                                  spontaneousCurvatureForceVec_gaussVec +
@@ -212,6 +225,7 @@ void System::computeGeometricForces(size_t i) {
       forces.maskForce(spontaneousCurvatureForceVec_schlafliVec, i);
   spontaneousCurvatureForceVec =
       forces.maskForce(spontaneousCurvatureForceVec, i);
+  gaussianCurvatureForceVec = forces.maskForce(gaussianCurvatureForceVec, i);
   deviatoricCurvatureForceVec_mean =
       forces.maskForce(deviatoricCurvatureForceVec_mean, i);
   deviatoricCurvatureForceVec_gauss =
@@ -234,6 +248,7 @@ void System::computeGeometricForces(size_t i) {
   forces.spontaneousCurvatureForceVec_schlafliVec[i] =
       spontaneousCurvatureForceVec_schlafliVec;
   forces.spontaneousCurvatureForceVec[i] = spontaneousCurvatureForceVec;
+  forces.gaussianCurvatureForceVec[i] = gaussianCurvatureForceVec;
   forces.deviatoricCurvatureForceVec[i] = deviatoricCurvatureForceVec;
   forces.deviatoricCurvatureForceVec_mean[i] = deviatoricCurvatureForceVec_mean;
   forces.deviatoricCurvatureForceVec_gauss[i] =
@@ -249,6 +264,8 @@ void System::computeGeometricForces(size_t i) {
   // Scalar force by projection to angle-weighted normal
   forces.spontaneousCurvatureForce[i] =
       forces.ontoNormal(spontaneousCurvatureForceVec, i);
+  forces.gaussianCurvatureForce[i] =
+      forces.ontoNormal(gaussianCurvatureForceVec, i);
   forces.deviatoricCurvatureForce[i] =
       forces.ontoNormal(deviatoricCurvatureForceVec, i);
   forces.areaDifferenceForce[i] = forces.ontoNormal(areaDifferenceForceVec, i);
@@ -313,14 +330,13 @@ void System::computeChemicalPotentials() {
   gcs::VertexData<double> dH0dphi(*geometry.mesh, 0);
   gcs::VertexData<double> dKbdphi(*geometry.mesh, 0);
   gcs::VertexData<double> dKddphi(*geometry.mesh, 0);
-  auto meanCurvDiff = (geometry.vpg->vertexMeanCurvatures.raw().array() /
-                       geometry.vpg->vertexDualAreas.raw().array()) -
-                      H0.raw().array();
+  gcs::VertexData<double> dKgdphi(*geometry.mesh, 0);
 
   if (parameters.bending.relation == "linear") {
     dH0dphi.fill(parameters.bending.H0c);
     dKbdphi.fill(parameters.bending.Kbc);
     dKddphi.fill(parameters.bending.Kdc);
+    dKgdphi.fill(parameters.bending.Kgc);
   } else if (parameters.bending.relation == "hill") {
     EigenVectorX1d proteinDensitySq =
         (proteinDensity.raw().array() * proteinDensity.raw().array()).matrix();
@@ -336,23 +352,35 @@ void System::computeChemicalPotentials() {
         (2 * parameters.bending.Kdc * proteinDensity.raw().array() /
          ((1 + proteinDensitySq.array()) * (1 + proteinDensitySq.array())))
             .matrix();
+    dKgdphi.raw() =
+        (2 * parameters.bending.Kgc * proteinDensity.raw().array() /
+         ((1 + proteinDensitySq.array()) * (1 + proteinDensitySq.array())))
+            .matrix();
   }
 
   if (parameters.bending.Kb != 0 || parameters.bending.Kbc != 0) {
+    auto meanCurvDiff = (geometry.vpg->vertexMeanCurvatures.raw().array() /
+                         geometry.vpg->vertexDualAreas.raw().array()) -
+                        H0.raw().array();
+
     forces.spontaneousCurvaturePotential.raw() = forces.maskProtein(
-        -geometry.vpg->vertexDualAreas.raw().array() *
-        (meanCurvDiff * meanCurvDiff * dKbdphi.raw().array() -
-         2 * Kb.raw().array() * meanCurvDiff * dH0dphi.raw().array()));
+        geometry.vpg->vertexDualAreas.raw().array() *
+        (4 * Kb.raw().array() * meanCurvDiff * dH0dphi.raw().array() -
+         2 * meanCurvDiff * meanCurvDiff * dKbdphi.raw().array()));
+  }
+
+  if (parameters.bending.Kg != 0 || parameters.bending.Kgc != 0) {
+    forces.gaussianCurvaturePotential.raw() =
+        -dKgdphi.raw().array() *
+        geometry.vpg->vertexGaussianCurvatures.raw().array();
   }
 
   if (parameters.bending.Kd != 0 || parameters.bending.Kdc != 0) {
     forces.deviatoricCurvaturePotential.raw() =
         -dKddphi.raw().array() *
-        geometry.vpg->vertexGaussianCurvatures.raw().array().square() /
-        geometry.vpg->vertexDualAreas.raw().array();
-    // (geometry.vpg->vertexMeanCurvatures.raw().array().square() /
-    //      geometry.vpg->vertexDualAreas.raw().array() -
-    //  geometry.vpg->vertexGaussianCurvatures.raw().array());
+        (geometry.vpg->vertexMeanCurvatures.raw().array().square() /
+             geometry.vpg->vertexDualAreas.raw().array() -
+         geometry.vpg->vertexGaussianCurvatures.raw().array());
   }
 
   if (parameters.adsorption.epsilon != 0)
@@ -395,8 +423,8 @@ void System::computeChemicalPotentials() {
   forces.chemicalPotential =
       forces.adsorptionPotential + forces.aggregationPotential +
       forces.entropyPotential + forces.spontaneousCurvaturePotential +
-      forces.deviatoricCurvaturePotential + forces.dirichletPotential +
-      forces.interiorPenaltyPotential;
+      forces.gaussianCurvaturePotential + forces.deviatoricCurvaturePotential +
+      forces.dirichletPotential + forces.interiorPenaltyPotential;
 }
 
 EigenVectorX1d
@@ -595,6 +623,7 @@ void System::computeConservativeForcing() {
   forces.spontaneousCurvatureForceVec_gaussVec.fill({0, 0, 0});
   forces.spontaneousCurvatureForceVec_schlafliVec.fill({0, 0, 0});
 
+  forces.gaussianCurvatureForceVec.fill({0, 0, 0});
   forces.deviatoricCurvatureForceVec.fill({0, 0, 0});
   forces.areaDifferenceForceVec.fill({0, 0, 0});
 
@@ -629,6 +658,7 @@ void System::computeConservativeForcing() {
 
   forces.dirichletPotential.raw().setZero();
   forces.spontaneousCurvaturePotential.raw().setZero();
+  forces.gaussianCurvaturePotential.raw().setZero();
   forces.deviatoricCurvaturePotential.raw().setZero();
   forces.adsorptionPotential.raw().setZero();
   forces.aggregationPotential.raw().setZero();
@@ -650,7 +680,7 @@ void System::computeConservativeForcing() {
     // summerize all conservative forces
     forces.conservativeForceVec =
         forces.osmoticForceVec + forces.capillaryForceVec +
-        forces.spontaneousCurvatureForceVec +
+        forces.spontaneousCurvatureForceVec + forces.gaussianCurvatureForceVec +
         forces.deviatoricCurvatureForceVec + forces.areaDifferenceForceVec +
         forces.lineCapillaryForceVec + forces.adsorptionForceVec +
         forces.aggregationForceVec + forces.entropyForceVec +

--- a/src/solver/init.cpp
+++ b/src/solver/init.cpp
@@ -214,6 +214,7 @@ bool System::updatePrescription(bool &ifMutateMesh, bool &ifUpdateNotableVertex,
           parameters.protein.prescribeProteinDensityDistribution(
               time, geometry.vpg->vertexMeanCurvatures.raw(),
               geometry.geodesicDistance.raw());
+      updateConfigurations();
     } else {
       ifUpdateProteinDensityDistribution = false;
       // mem3dg_runtime_warning("Parameter protein form is NULL!")

--- a/src/solver/init.cpp
+++ b/src/solver/init.cpp
@@ -109,6 +109,8 @@ void System::updateConfigurations() {
                parameters.bending.Kbc * proteinDensity.raw().array();
     Kd.raw() = parameters.bending.Kd +
                parameters.bending.Kdc * proteinDensity.raw().array();
+    Kg.raw() = parameters.bending.Kg +
+               parameters.bending.Kgc * proteinDensity.raw().array();
   } else if (parameters.bending.relation == "hill") {
     EigenVectorX1d proteinDensitySq =
         (proteinDensity.raw().array() * proteinDensity.raw().array()).matrix();
@@ -118,6 +120,9 @@ void System::updateConfigurations() {
                                            proteinDensitySq.array() /
                                            (1 + proteinDensitySq.array());
     Kd.raw() = parameters.bending.Kd + parameters.bending.Kdc *
+                                           proteinDensitySq.array() /
+                                           (1 + proteinDensitySq.array());
+    Kg.raw() = parameters.bending.Kg + parameters.bending.Kgc *
                                            proteinDensitySq.array() /
                                            (1 + proteinDensitySq.array());
   } else {

--- a/src/solver/integrator/forward_euler.cpp
+++ b/src/solver/integrator/forward_euler.cpp
@@ -35,7 +35,6 @@ namespace integrator {
 namespace gc = ::geometrycentral;
 
 bool Euler::integrate() {
-
   if (ifDisableIntegrate)
     mem3dg_runtime_error("integrate() is disabled for current construction!");
 
@@ -101,7 +100,6 @@ bool Euler::integrate() {
 
     if (system.updatePrescription(lastUpdateTime, timeStep)) {
       system.time += 1e-5 * timeStep;
-      system.updateConfigurations(); // Update configurations after mutation
     } else {
       march();
     }

--- a/src/solver/integrator/integrator.cpp
+++ b/src/solver/integrator/integrator.cpp
@@ -410,7 +410,7 @@ void Integrator::saveData(bool outputTrajFile, bool outputMeshFile,
     if (timeStep != characteristicTimeStep && printToConsole) {
       std::cout << "timeStep: " << characteristicTimeStep << " -> " << timeStep
                 << std::endl;
-      system.testConservativeForcing(characteristicTimeStep);
+      system.testConservativeForcing(timeStep);
     }
 
     if (EXIT)

--- a/src/solver/io.cpp
+++ b/src/solver/io.cpp
@@ -57,6 +57,8 @@ void System::saveRichData(std::string PathToSave, bool isJustGeometry) {
     // write pressures
     richData.addVertexProperty("spontaneousCurvatureForce",
                                forces.spontaneousCurvatureForce);
+    richData.addVertexProperty("gaussianCurvatureForce",
+                               forces.gaussianCurvatureForce);
     richData.addVertexProperty("deviatoricCurvatureForce",
                                forces.deviatoricCurvatureForce);
     richData.addVertexProperty("areaDifferenceForce",
@@ -74,6 +76,8 @@ void System::saveRichData(std::string PathToSave, bool isJustGeometry) {
     richData.addVertexProperty("dirichletPotential", forces.dirichletPotential);
     richData.addVertexProperty("spontaneousCurvaturePotential",
                                forces.spontaneousCurvaturePotential);
+    richData.addVertexProperty("gaussianCurvaturePotential",
+                               forces.gaussianCurvaturePotential);
     richData.addVertexProperty("deviatoricCurvaturePotential",
                                forces.deviatoricCurvaturePotential);
     richData.addVertexProperty("adsorptionPotential",

--- a/src/solver/misc.cpp
+++ b/src/solver/misc.cpp
@@ -170,11 +170,10 @@ bool summarizeTracingResults(double actualDelta1, double expectedDelta1,
 } // namespace detail
 
 bool System::testConservativeForcing(const double timeStep) {
-  std::cout << "<<<<<" << std::endl;
-  mem3dg_runtime_warning("numerically testing componentwise forcing--energy "
-                         "relation (<--'s highlight possible inconsistency)");
-  std::cout << "\nUsing time step " << timeStep << ":" << std::endl;
-  std::cout << "\n";
+  mem3dg_print("<<<<<");
+  mem3dg_print("numerically testing componentwise forcing--energy "
+               "relation (<--'s highlight possible inconsistency)");
+  mem3dg_print_nospace("Using time step ", timeStep, ":\n");
   updateConfigurations();
   computeTotalEnergy();
   computeConservativeForcing();
@@ -276,6 +275,21 @@ bool System::testConservativeForcing(const double timeStep) {
                            energy.areaDifferenceEnergy,
                            "areaDifferenceForceVec", "areaDifferenceEnergy") &&
             SUCCESS;
+  // ==========================================================
+  // ================ Gaussian curvature   ==================
+  // ==========================================================
+  SUCCESS =
+      testMechanical(forces.gaussianCurvatureForceVec,
+                     previousEnergy.gaussianCurvatureEnergy,
+                     energy.gaussianCurvatureEnergy,
+                     "gaussianCurvatureForceVec", "gaussianCurvatureEnergy") &&
+      SUCCESS;
+  SUCCESS =
+      testChemical(forces.gaussianCurvaturePotential,
+                   previousEnergy.gaussianCurvatureEnergy,
+                   energy.gaussianCurvatureEnergy, "gaussianCurvaturePotential",
+                   "gaussianCurvatureEnergy") &&
+      SUCCESS;
   // ==========================================================
   // ================ Deviatoric curvature   ==================
   // ==========================================================
@@ -413,29 +427,6 @@ bool System::testConservativeForcing(const double timeStep) {
   return SUCCESS;
 }
 
-// void System::check_pcg() {
-//   // Generate a normal distribution around that mean
-//   std::normal_distribution<> normal_dist(0, 2);
-
-//   // Make a copy of the RNG state to use later
-//   pcg32 rng_checkpoint = rng;
-
-//   // Produce histogram
-//   std::map<int, int> hist;
-//   for (int n = 0; n < 10000; ++n) {
-//     ++hist[std::round(normal_dist(rng))];
-//   }
-//   std::cout << "Normal distribution around " << 0 << ":\n";
-//   for (auto p : hist) {
-//     std::cout << std::fixed << std::setprecision(1) << std::setw(2) <<
-//     p.first
-//               << ' ' << std::string(p.second / 30, '*') << '\n';
-//   }
-
-//   // Produce information about RNG usage
-//   std::cout << "Required " << (rng - rng_checkpoint) << " random numbers.\n";
-// }
-
 bool System::checkFiniteness() {
   bool finite = true;
   if (!std::isfinite(mechErrorNorm)) {
@@ -457,6 +448,9 @@ bool System::checkFiniteness() {
       if (!std::isfinite(
               toMatrix(forces.spontaneousCurvatureForceVec).norm())) {
         mem3dg_runtime_warning("Spontaneous curvature force is not finite!");
+      }
+      if (!std::isfinite(toMatrix(forces.gaussianCurvatureForceVec).norm())) {
+        mem3dg_runtime_warning("Gaussian curvature force is not finite!");
       }
       if (!std::isfinite(toMatrix(forces.deviatoricCurvatureForceVec).norm())) {
         mem3dg_runtime_warning("Deviatoric curvature force is not finite!");
@@ -497,6 +491,9 @@ bool System::checkFiniteness() {
         mem3dg_runtime_warning(
             "Spontaneous curvature Potential is not finite!");
       }
+      if (!std::isfinite(forces.gaussianCurvaturePotential.raw().norm())) {
+        mem3dg_runtime_warning("Gaussian curvature Potential is not finite!");
+      }
       if (!std::isfinite(forces.deviatoricCurvaturePotential.raw().norm())) {
         mem3dg_runtime_warning("Deviatoric curvature Potential is not finite!");
       }
@@ -530,6 +527,9 @@ bool System::checkFiniteness() {
     if (!std::isfinite(energy.potentialEnergy)) {
       if (!std::isfinite(energy.spontaneousCurvatureEnergy)) {
         mem3dg_runtime_warning("Spontaneous curvature energy is not finite!");
+      }
+      if (!std::isfinite(energy.gaussianCurvatureEnergy)) {
+        mem3dg_runtime_warning("Gaussian curvature energy is not finite!");
       }
       if (!std::isfinite(energy.deviatoricCurvatureEnergy)) {
         mem3dg_runtime_warning("Deviatoric curvature energy is not finite!");

--- a/src/solver/misc.cpp
+++ b/src/solver/misc.cpp
@@ -46,21 +46,17 @@ void System::backtraceEnergyGrowth(const double timeStep,
   if (parameters.external.form != NULL)
     computeExternalWork(time, timeStep);
   computeTotalEnergy();
-  std::cout << "<<<<<" << std::endl;
-  mem3dg_runtime_warning("backtracing the component that leads to the energy "
-                         "growth (<--'s highlight growing components)");
-  std::cout << "\nUsing time step " << timeStep << ":" << std::endl;
-  std::cout << "\n";
+  mem3dg_print("<<<<<");
+  mem3dg_print("back tracing the component that leads to the energy "
+               "growth (<--'s highlight growing components)");
+  mem3dg_print("Using time step ", timeStep, ":\n");
   auto checkGrowth = [](const double &previousEnergy,
                         const double &currentEnergy, std::string key) {
     if (currentEnergy != previousEnergy) {
       std::string marker = "";
       if (currentEnergy > previousEnergy || !std::isfinite(currentEnergy))
         marker = " <--";
-      std::cout << key << " increased "
-                << currentEnergy - previousEnergy
-                // << " from " << previousEnergy << " to " << currentEnergy
-                << marker << std::endl;
+      mem3dg_print(key, "increased", currentEnergy - previousEnergy, marker);
     }
   };
   checkGrowth(previousEnergy.potentialEnergy, energy.potentialEnergy,
@@ -92,8 +88,86 @@ void System::backtraceEnergyGrowth(const double timeStep,
               "faceSpringEnergy");
   checkGrowth(previousEnergy.lcrSpringEnergy, energy.lcrSpringEnergy,
               "lcrSpringEnergy");
-  std::cout << ">>>>>" << std::endl;
+  mem3dg_print(">>>>>");
 };
+
+namespace detail {
+bool summarizeTracingResults(double actualDelta1, double expectedDelta1,
+                             double actualDelta2, double expectedDelta2,
+                             double stepFold, std::string key,
+                             double currentEnergy,
+                             double floatTolerance = 1e-15,
+                             double deltaEnergyTolerance = 0.01,
+                             double convergenceTolerance = 0.03) {
+  double expectRate = 2;
+  int precision = 5;
+  std::string marker = " <-----\n";
+  // // PRINT LINE SPACINGS
+  // std::ostringstream ss;
+  // for (int i = 0; i < 10; ++i) {
+  //   for (int j = 0; j < 10; ++j) {
+  //     ss << i;
+  //   }
+  // }
+  // ss << std::endl;
+  // for (int i = 0; i < 10; ++i) {
+  //   for (int j = 0; j < 10; ++j) {
+  //     ss << j;
+  //   }
+  // }
+  // std::cout << ss.str() << std::endl;
+  // mem3dg_print("Using tolerances (float, ΔE, convergence):", floatTolerance,
+  //              deltaEnergyTolerance, convergenceTolerance);
+
+  key = key + std::string(": ");
+
+  mem3dg_print_nospace(std::left, std::setw(35), key);
+  double difference_h = abs(expectedDelta1 - actualDelta1);
+  if (actualDelta1 != 0) {
+    mem3dg_print_nospace(std::left, std::setw(10), "decrease", std::right,
+                         std::setw(10), std::setprecision(precision),
+                         actualDelta1, ", ", std::left, std::setw(10), "expect",
+                         std::right, std::setw(10),
+                         std::setprecision(precision), expectedDelta1);
+
+    if ((actualDelta1 < 0) || !std::isfinite(currentEnergy) ||
+        (difference_h / abs(actualDelta1)) >
+            deltaEnergyTolerance) { // criteria 1: closeness
+      mem3dg_print_noendl(marker, "\n");
+      return false;
+    } else {
+      mem3dg_print_noendl("\n");
+    }
+  } else {
+    mem3dg_print("inactivated", marker);
+    return true;
+  }
+
+  // test using x * timeStep for convergence
+  double difference_xh = abs(expectedDelta2 - actualDelta2);
+  if (difference_h < floatTolerance &&
+      difference_xh < floatTolerance) { // probably exact
+    mem3dg_print(std::setw(35), "exact\n");
+    return true;
+  }
+  mem3dg_print_nospace(std::setw(35), " ", std::left, std::setw(10), "converge",
+                       std::right, std::setw(10), std::setprecision(precision),
+                       pow(difference_xh / difference_h, 1 / expectRate), ", ",
+                       std::left, std::setw(10), "expect ", std::right,
+                       std::setw(10), std::setprecision(precision), expectRate);
+
+  if (abs(difference_xh / difference_h - pow(stepFold, expectRate)) >
+      convergenceTolerance) { // criteria 2: convergence rate
+    mem3dg_print_noendl(marker, "\n");
+    return false;
+  } else {
+    mem3dg_print_noendl("\n");
+  }
+
+  mem3dg_print_noendl("\n");
+  return true;
+};
+} // namespace detail
 
 bool System::testConservativeForcing(const double timeStep) {
   std::cout << "<<<<<" << std::endl;
@@ -111,80 +185,13 @@ bool System::testConservativeForcing(const double timeStep) {
 
   bool SUCCESS = true;
 
-  auto summerize = [](double actualDelta1, double expectedDelta1,
-                      double actualDelta2, double expectedDelta2,
-                      double stepFold, std::string key, double currentEnergy) {
-    double expectRate = 2;
-    std::array<std::size_t, 2> alignment{35, 60};
-    std::array<std::size_t, 2> space;
-    key = key + std::string(": ");
-    space[0] = alignment[0] - key.length();
-
-    std::ostringstream half1;
-    half1 << "decrease " << actualDelta1 << ", ";
-    space[1] = alignment[1] - half1.str().length() - alignment[0];
-
-    std::string marker = " <-----\n";
-
-    std::cout << key;
-    for (std::size_t i = 0; i < space[0]; i++) // for console readability
-      std::cout << " ";
-    double difference_h = abs(expectedDelta1 - actualDelta1);
-    if (actualDelta1 != 0) {
-      std::cout << half1.str();
-      for (std::size_t i = 0; i < space[1]; i++) // for console readability
-        std::cout << " ";
-      std::cout << "expect " << expectedDelta1;
-      if ((actualDelta1 < 0) || !std::isfinite(currentEnergy) ||
-          (difference_h / abs(actualDelta1)) > 0.01) { // criteria 1: closeness
-        std::cout << marker << std::endl;
-        return false;
-      } else {
-        std::cout << "" << std::endl;
-      }
-    } else {
-      std::cout << "inactivated" << marker << std::endl;
-      return false;
-    }
-
-    // test using x * timeStep for convergence
-    space[0] = alignment[0];
-    double difference_xh = abs(expectedDelta2 - actualDelta2);
-    if (difference_h < 1e-15 && difference_xh < 1e-15) { // probably exact
-      for (std::size_t i = 0; i < space[0]; i++) // for console readability
-        std::cout << " ";
-      std::cout << "exact\n" << std::endl;
-      return true;
-    }
-    for (std::size_t i = 0; i < space[0]; i++) // for console readability
-      std::cout << " ";
-    std::ostringstream half2;
-    half2 << "converge with "
-          << pow(difference_xh / difference_h, 1 / expectRate) << ", ";
-    space[1] = alignment[1] - half2.str().length() - alignment[0];
-    std::cout << half2.str();
-    for (std::size_t i = 0; i < space[1]; i++) // for console readability
-      std::cout << " ";
-    std::cout << "expect " << expectRate;
-    if (abs(difference_xh / difference_h - pow(stepFold, expectRate)) >
-        0.03) { // criteria 2: convergence rate
-      std::cout << marker << std::endl;
-      return false;
-    } else {
-      std::cout << "" << std::endl;
-    }
-
-    std::cout << "" << std::endl;
-    return true;
-  };
-
   // lambda function to test mechanical forces
   auto testMechanical = [previousProteinDensity, previousPosition, timeStep,
-                         this, summerize](
-                            gcs::VertexData<gc::Vector3> &forceVec,
-                            const double &previousEnergy,
-                            const double &currentEnergy, std::string forceKey,
-                            [[maybe_unused]] std::string energyKey) {
+                         this](gcs::VertexData<gc::Vector3> &forceVec,
+                               const double &previousEnergy,
+                               const double &currentEnergy,
+                               std::string forceKey,
+                               [[maybe_unused]] std::string energyKey) {
     double stepFold = 2;
     std::string key = forceKey; // + std::string("--") + energyKey;
 
@@ -207,37 +214,42 @@ bool System::testConservativeForcing(const double timeStep) {
     double actualDelta1, expectedDelta1, actualDelta2, expectedDelta2;
     std::tie(actualDelta1, expectedDelta1) = computeDelta(timeStep);
     std::tie(actualDelta2, expectedDelta2) = computeDelta(stepFold * timeStep);
-    return summerize(actualDelta1, expectedDelta1, actualDelta2, expectedDelta2,
-                     stepFold, key, currentEnergy);
+    return detail::summarizeTracingResults(actualDelta1, expectedDelta1,
+                                           actualDelta2, expectedDelta2,
+                                           stepFold, key, currentEnergy);
   };
 
-  auto testChemical = [previousProteinDensity, previousPosition, timeStep, this,
-                       summerize](gcs::VertexData<double> &potential,
-                                  const double &previousEnergy,
-                                  const double &currentEnergy,
-                                  std::string potentialKey,
-                                  [[maybe_unused]] std::string energyKey) {
+  auto testChemical = [previousProteinDensity, previousPosition, timeStep,
+                       this](gcs::VertexData<double> &chemPotential,
+                             const double &previousEnergy,
+                             const double &currentEnergy,
+                             std::string chemPotentialKey,
+                             [[maybe_unused]] std::string energyKey) {
     double stepFold = 2;
-    std::string key = potentialKey; // + std::string("--") + energyKey;
+    std::string key = chemPotentialKey; // + std::string("--") + energyKey;
 
     // lambda function to compute energy delta
     auto computeDelta = [&](double dt) {
       toMatrix(geometry.vpg->inputVertexPositions) = previousPosition;
       proteinDensity.raw() =
-          previousProteinDensity +
-          dt * parameters.proteinMobility * forces.maskProtein(potential.raw());
+          previousProteinDensity + dt * parameters.proteinMobility *
+                                       forces.maskProtein(chemPotential.raw());
       updateConfigurations();
       computeTotalEnergy();
       double actualDelta = -currentEnergy + previousEnergy;
-      double expectedDelta = dt * parameters.proteinMobility *
-                             forces.maskProtein(potential.raw()).squaredNorm();
+      double expectedDelta =
+          dt * parameters.proteinMobility *
+          forces.maskProtein(chemPotential.raw()).squaredNorm();
+      forces.maskProtein(chemPotential.raw()).squaredNorm();
+      forces.maskProtein(chemPotential.raw()).squaredNorm();
       return std::tuple<double, double>(actualDelta, expectedDelta);
     };
     double actualDelta1, expectedDelta1, actualDelta2, expectedDelta2;
     std::tie(actualDelta1, expectedDelta1) = computeDelta(timeStep);
     std::tie(actualDelta2, expectedDelta2) = computeDelta(stepFold * timeStep);
-    return summerize(actualDelta1, expectedDelta1, actualDelta2, expectedDelta2,
-                     stepFold, key, currentEnergy);
+    return detail::summarizeTracingResults(actualDelta1, expectedDelta1,
+                                           actualDelta2, expectedDelta2,
+                                           stepFold, key, currentEnergy);
   };
 
   // ==========================================================

--- a/tests/python/pytest/test_core.py
+++ b/tests/python/pytest/test_core.py
@@ -87,7 +87,7 @@ class TestInitialization(object):
 
         # protein
         system.parameters.protein.prescribeProteinDensityDistribution = partial(
-            dg_boil.prescribeGeodesicPoteinDensityDistribution,
+            dg_boil.prescribeGeodesicProteinDensityDistribution,
             sharpness=20,
             radius=0.5,
         )

--- a/tests/src/force_test.cpp
+++ b/tests/src/force_test.cpp
@@ -80,10 +80,12 @@ protected:
     p.bending.alpha = 1;
     p.bending.dA0 = 4;
     p.bending.D = 0.01;
+    p.bending.Kg = -10.22e-5;
+    p.bending.Kgc = -1.1 * 10.22e-5;
     p.bending.Kd = 8.22e-5;
-    p.bending.Kdc = 8.22e-5;
-    p.bending.Kb = 8.22e-5;
-    p.bending.Kbc = 0;
+    p.bending.Kdc = 1.1 * 8.22e-5;
+    p.bending.Kb = 4.22e-5;
+    p.bending.Kbc = 1.2 * 4.22e-5;
     p.bending.H0c = -1;
 
     auto constantSurfaceTensionModel = [](double area) {
@@ -208,10 +210,10 @@ protected:
     p.variation.isShapeVariation = true;
     p.variation.isProteinVariation = false;
 
-    p.bending.Kd = -8.22e-5;
-    p.bending.Kdc = 0;
-    p.bending.Kb = 8.22e-5;
-    p.bending.Kbc = 0;
+    p.bending.Kg = 0;
+    p.bending.Kgc = -8.22e-5;
+    p.bending.Kb = 0;
+    p.bending.Kbc = 8.22e-5;
     p.bending.H0c = 6;
 
     auto constantSurfaceTensionModel = [](double area) {

--- a/tests/src/force_test.cpp
+++ b/tests/src/force_test.cpp
@@ -31,9 +31,8 @@
 namespace mem3dg {
 namespace solver {
 namespace gc = ::geometrycentral;
-namespace gcs = ::geometrycentral::surface;
 
-class ForceTest : public testing::Test {
+class CylinderForceTest : public testing::Test {
 protected:
   // initialize mesh and vpg
   // std::unique_ptr<gcs::ManifoldSurfaceMesh> ptrMesh;
@@ -46,7 +45,7 @@ protected:
   Eigen::Matrix<bool, Eigen::Dynamic, 1> notableVertex;
   double h = 0.1;
 
-  ForceTest() {
+  CylinderForceTest() {
     // Create mesh and geometry objects
     std::tie(topologyMatrix, vertexMatrix) =
         getCylinderMatrix(1, 10, 10, 5, 0.3);
@@ -131,7 +130,7 @@ protected:
  * when computed twice
  *
  */
-TEST_F(ForceTest, ConservativeForcesTest) {
+TEST_F(CylinderForceTest, ConservativeForcesTest) {
   // Instantiate system object
   mem3dg::solver::Geometry geometry(topologyMatrix, vertexMatrix,
                                     notableVertex);
@@ -163,7 +162,7 @@ TEST_F(ForceTest, ConservativeForcesTest) {
  * 1. decrease in energy
  * 2. decrease in second order (or exact)
  */
-TEST_F(ForceTest, ConsistentForceEnergy) {
+TEST_F(CylinderForceTest, ConsistentForceEnergy) {
 
   // initialize the system
   mem3dg::solver::Geometry geometry(topologyMatrix, vertexMatrix,
@@ -185,5 +184,112 @@ TEST_F(ForceTest, ConsistentForceEnergy) {
 
   EXPECT_TRUE(f.testConservativeForcing(h));
 };
+
+class CylinderRollerTest : public testing::Test {
+protected:
+  // initialize mesh and vpg
+  // std::unique_ptr<gcs::ManifoldSurfaceMesh> ptrMesh;
+  // std::unique_ptr<gcs::VertexPositionGeometry> ptrVpg;
+  Eigen::Matrix<std::size_t, Eigen::Dynamic, 3, Eigen::RowMajor> topologyMatrix;
+  Eigen::Matrix<double, Eigen::Dynamic, 3, Eigen::RowMajor> vertexMatrix;
+  EigenVectorX1d proteinDensity;
+  EigenVectorX3dr velocity;
+  Parameters p;
+  Eigen::Matrix<bool, Eigen::Dynamic, 1> notableVertex;
+  double h = 0.05;
+
+  CylinderRollerTest() {
+    // Create mesh and geometry objects
+    std::tie(topologyMatrix, vertexMatrix) =
+        getCylinderMatrix(1, 10, 10, 5, 0.3);
+    proteinDensity = Eigen::MatrixXd::Constant(vertexMatrix.rows(), 1, 1);
+    velocity = Eigen::MatrixXd::Constant(vertexMatrix.rows(), 3, 0);
+
+    p.variation.isShapeVariation = true;
+    p.variation.isProteinVariation = false;
+
+    p.bending.Kd = -8.22e-5;
+    p.bending.Kdc = 0;
+    p.bending.Kb = 8.22e-5;
+    p.bending.Kbc = 0;
+    p.bending.H0c = 6;
+
+    auto constantSurfaceTensionModel = [](double area) {
+      double tension = 1e-2;
+      double energy = tension * area;
+      return std::make_tuple(tension, energy);
+    };
+    p.tension.form = constantSurfaceTensionModel;
+
+    auto constantOmosticPressureModel = [](double volume) {
+      double osmoticPressure = 1e-2;
+      double pressureEnergy = -osmoticPressure * volume;
+      return std::make_tuple(osmoticPressure, pressureEnergy);
+    };
+    p.osmotic.form = constantOmosticPressureModel;
+
+    p.boundary.shapeBoundaryCondition = "roller";
+    p.boundary.proteinBoundaryCondition = "none";
+  }
+};
+
+/**
+ * @brief Test whether force is conservative: result need to be the same
+ * when computed twice
+ *
+ */
+TEST_F(CylinderRollerTest, ConservativeRollerTest) {
+  // Instantiate system object
+  mem3dg::solver::Geometry geometry(topologyMatrix, vertexMatrix);
+  mem3dg::solver::System f(geometry, proteinDensity, velocity, p, 0);
+  f.initialize(false);
+  f.updateConfigurations();
+  // First time calculation of force
+  f.computeConservativeForcing();
+  EigenVectorX3dr conservativeForceVec1 =
+      toMatrix(f.forces.conservativeForceVec);
+  EigenVectorX1d chemicalPotential1 = f.forces.chemicalPotential.raw();
+  // Second time calculation of force
+  f.computeConservativeForcing();
+  EigenVectorX3dr conservativeForceVec2 =
+      toMatrix(f.forces.conservativeForceVec);
+  EigenVectorX1d chemicalPotential2 = f.forces.chemicalPotential.raw();
+
+  // Comparison of 2 force calculations
+  EXPECT_TRUE(conservativeForceVec1.isApprox(conservativeForceVec2));
+  EXPECT_TRUE(chemicalPotential1.isApprox(chemicalPotential2));
+  //   EXPECT_TRUE((conservativeForceVec1 - conservativeForceVec2).norm() <
+  //   1e-12); EXPECT_TRUE((chemicalPotential1 - chemicalPotential2).norm() <
+  //   1e-12); EXPECT_TRUE((regularizationForce1 - regularizationForce2).norm()
+  //   < 1e-12);
+};
+
+/**
+ * @brief Test whether integrating with the force will lead to
+ * 1. decrease in energy
+ * 2. decrease in second order (or exact)
+ */
+TEST_F(CylinderRollerTest, ConsistentRollerEnergy) {
+
+  // initialize the system
+  mem3dg::solver::Geometry geometry(topologyMatrix, vertexMatrix);
+  mem3dg::solver::System f(geometry, proteinDensity, velocity, p, 0);
+
+  // A few sanity checks to ensure that ref VPG matches
+  EigenVectorX3dr vpg = toMatrix(f.geometry.vpg->inputVertexPositions);
+  EigenVectorX3dr refvpg = toMatrix(f.geometry.refVpg->inputVertexPositions);
+  EXPECT_TRUE(vpg.isApprox(refvpg));
+
+  // Manually perturb refvpg to force spring penalty
+  std::tie(std::ignore, refvpg) = getCylinderMatrix(1, 10, 10);
+  gc::EigenMap<double, 3>(f.geometry.refVpg->inputVertexPositions) = refvpg;
+  f.geometry.refVpg->refreshQuantities();
+
+  f.initialize(false);
+  f.updateConfigurations();
+
+  EXPECT_TRUE(f.testConservativeForcing(h));
+};
+
 } // namespace solver
 } // namespace mem3dg


### PR DESCRIPTION
## Description
Previously we used a non-standard form of the Helfrich energy which is related to the broader literature by a factor of two. To prevent mistakes in assigning parameters from the broader literature we have switched to follow the form of the original Helfrich equation.

Before:
$E_b = \int_{\mathcal{M}}\left[\kappa(H-\bar{H})^{2}+\kappa_{G} K\right] dA.$ 

After:
$E_b = \int_{\mathcal{M}}\left[2\kappa(H-\bar{H})^{2}+\kappa_{G} K\right] dA.$ 

This PR also adds some additional convenience features and restores the conventional contribution from the Gaussian curvature term.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Switch to standard Helfrich
  - [x] Restore Gaussian curvature term
  - [x] Improvements to printing to console
  - [x] Bumps Geometry-central to the latest version. 

## Questions
N/A

## Status
- [x] Ready to go
