### PR TITLE
Fix mesh mutation frequency

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,46 +59,46 @@ jobs:
           cmake --build . --config Release -j 4
           ctest -C Release -V -j 4
 
-  # build_macos:
-  #   name: Build-Test macOS
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       os: [macos-15]
-  #   runs-on: ${{ matrix.os }}
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #       with:
-  #         fetch-depth: 0
-  #         submodules: recursive
+  build_macos:
+    name: Build-Test macOS
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest]
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          submodules: recursive
 
-  #     - uses: actions/setup-python@v5
-  #       id: pyexe
-  #       with:
-  #         python-version: '3.10'
+      - uses: actions/setup-python@v5
+        id: pyexe
+        with:
+          python-version: '3.10'
 
-  #     # - name: Setup python libs
-  #     #   id: pyexe
-  #     #   run: |
-  #     #     python3 --version
-  #     #     # python3 -m pip install pytest
-  #     #     py_exe_path=$(which python3)
-  #     #     echo ::set-output name=path::$py_exe_path
+      # - name: Setup python libs
+      #   id: pyexe
+      #   run: |
+      #     python3 --version
+      #     # python3 -m pip install pytest
+      #     py_exe_path=$(which python3)
+      #     echo ::set-output name=path::$py_exe_path
 
-  #     - name: Resolve dependencies
-  #       run: brew install netcdf eigen pybind11 netcdf-cxx
+      - name: Resolve dependencies
+        run: brew install netcdf eigen pybind11 netcdf-cxx
 
-  #     - name: Build
-  #       run: |
-  #         mkdir -p build && cd build;
-  #         cmake -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_PYMEM3DG=ON -DSUITESPARSE=OFF -DWITH_NETCDF=ON -DPython_EXECUTABLE:FILEPATH=${{ steps.pyexe.outputs.python-path }} --log-level=DEBUG ..
-  #         cmake --build . --config Release -j 4
+      - name: Build
+        run: |
+          mkdir -p build && cd build;
+          cmake -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_PYMEM3DG=ON -DSUITESPARSE=OFF -DWITH_NETCDF=ON -DPython_EXECUTABLE:FILEPATH=${{ steps.pyexe.outputs.python-path }} --log-level=DEBUG ..
+          cmake --build . --config Release -j 4
 
-  #     - name: Test
-  #       run: ctest -C Release -V -j 4
+      - name: Test
+        run: ctest -C Release -V -j 4
 
 
   # build_windows:
@@ -211,7 +211,7 @@ jobs:
     name: Deploy to PyPI
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [build_linux]
+    needs: [build_linux, build_macos]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,9 @@ on:
       - main
       - development
 
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
 jobs:
   build_linux:
     name: Build-Test Linux
@@ -56,46 +59,46 @@ jobs:
           cmake --build . --config Release -j 4
           ctest -C Release -V -j 4
 
-  build_macos:
-    name: Build-Test macOS
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest]
-    runs-on: ${{ matrix.os }}
-    defaults:
-      run:
-        shell: bash
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          submodules: recursive
+  # build_macos:
+  #   name: Build-Test macOS
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       os: [macos-15]
+  #   runs-on: ${{ matrix.os }}
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #       with:
+  #         fetch-depth: 0
+  #         submodules: recursive
 
-      - uses: actions/setup-python@v5
-        id: pyexe
-        with:
-          python-version: '3.10'
+  #     - uses: actions/setup-python@v5
+  #       id: pyexe
+  #       with:
+  #         python-version: '3.10'
 
-      # - name: Setup python libs
-      #   id: pyexe
-      #   run: |
-      #     python3 --version
-      #     # python3 -m pip install pytest
-      #     py_exe_path=$(which python3)
-      #     echo ::set-output name=path::$py_exe_path
+  #     # - name: Setup python libs
+  #     #   id: pyexe
+  #     #   run: |
+  #     #     python3 --version
+  #     #     # python3 -m pip install pytest
+  #     #     py_exe_path=$(which python3)
+  #     #     echo ::set-output name=path::$py_exe_path
 
-      - name: Resolve dependencies
-        run: brew install netcdf eigen pybind11 netcdf-cxx
+  #     - name: Resolve dependencies
+  #       run: brew install netcdf eigen pybind11 netcdf-cxx
 
-      - name: Build
-        run: |
-          mkdir -p build && cd build;
-          cmake -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_PYMEM3DG=ON -DSUITESPARSE=OFF -DWITH_NETCDF=ON -DPython_EXECUTABLE:FILEPATH=${{ steps.pyexe.outputs.python-path }} --log-level=DEBUG ..
-          cmake --build . --config Release -j 4
+  #     - name: Build
+  #       run: |
+  #         mkdir -p build && cd build;
+  #         cmake -DCMAKE_BUILD_TYPE=RELEASE -DBUILD_PYMEM3DG=ON -DSUITESPARSE=OFF -DWITH_NETCDF=ON -DPython_EXECUTABLE:FILEPATH=${{ steps.pyexe.outputs.python-path }} --log-level=DEBUG ..
+  #         cmake --build . --config Release -j 4
 
-      - name: Test
-        run: ctest -C Release -V -j 4
+  #     - name: Test
+  #       run: ctest -C Release -V -j 4
 
 
   # build_windows:
@@ -208,7 +211,7 @@ jobs:
     name: Deploy to PyPI
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [build_linux, build_macos]
+    needs: [build_linux]
     defaults:
       run:
         shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,25 @@ option(WITH_LIBUNWIND "Link libunwind for stack traces" OFF)
 option(WITH_OPENMP "Build with OpenMP support" OFF)
 option(LINK_PROFILER "Link profiler gperftools" OFF)
 
+if(CMAKE_PROJECT_NAME STREQUAL "mem3dg")
+  option(BUILD_SHARED_LIBS
+         "Build shared libraries (.dll/.so) instead of static ones (.lib/.a)"
+         OFF
+  )
+endif()
+
+# option(BUILD_SHARED_LIBS "Build using shared libraries" ON)
+
 option(MEM3DG_PEDANTIC "Be extremely pedantic while compiling" OFF)
 
 mark_as_advanced(FORCE MEM3DG_PEDANTIC)
+
+if(BUILD_PYMEM3DG AND BUILD_SHARED_LIBS)
+  message(
+    FATAL_ERROR
+      "Cannot build shared libraries with Python bindings. Please set BUILD_PYMEM3DG=OFF or BUILD_SHARED_LIBS=OFF"
+  )
+endif()
 
 # ##############################################################################
 # BUNDLED LIBRARIES & EXTERNAL LIBS
@@ -91,13 +107,6 @@ if(WITH_NETCDF)
   if(VCPKG_TARGET_TRIPLET)
     message(STATUS "VCPKG Triplet: ${VCPKG_TARGET_TRIPLET}")
   endif()
-  find_package(netCDF "4.3.1" REQUIRED)
-  message(DEBUG "netCDF version: ${netCDF_VERSION}")
-  message(DEBUG "netCDF dir: ${netCDF_DIR}")
-  message(DEBUG "netCDF include dir: ${netCDF_INCLUDE_DIR}")
-  message(DEBUG "netCDF libraries: ${netCDF_LIBRARIES}")
-  list(APPEND LINKED_LIBS NetCDF::NetCDF)
-
   find_package(netcdf-cxx4 REQUIRED)
   message(DEBUG "netcdf-cxx4 include: ${netcdf-cxx4_INCLUDE_DIRS}")
   message(DEBUG "netcdf-cxx4 library: ${netcdf-cxx4_LIBRARIES}")
@@ -154,7 +163,7 @@ if(MEM3DG_PEDANTIC)
 endif()
 
 # mem3dg library
-add_library(mem3dg SHARED $<TARGET_OBJECTS:mem3dg_objlib>)
+add_library(mem3dg $<TARGET_OBJECTS:mem3dg_objlib>)
 target_link_libraries(mem3dg PUBLIC mem3dg_objlib)
 
 if(BUILD_PYMEM3DG)
@@ -179,11 +188,12 @@ install(
   TARGETS mem3dg
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT Runtime
 )
 install(
   DIRECTORY include/mem3dg
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  COMPONENT Development
   FILES_MATCHING
   PATTERN "*.h"
 )

--- a/cmake/DefaultBuildTypeAndFlags.cmake
+++ b/cmake/DefaultBuildTypeAndFlags.cmake
@@ -37,33 +37,9 @@ endif()
 
 if(MSVC)
   option(USE_MSVC_RUNTIME_LIBRARY_DLL "Use MSVC runtime library DLL" ON)
-
-  if(CMAKE_VERSION VERSION_LESS 3.15 AND NOT USE_MSVC_RUNTIME_LIBRARY_DLL)
-    foreach(
-      flag
-      CMAKE_C_FLAGS
-      CMAKE_C_FLAGS_DEBUG
-      CMAKE_C_FLAGS_RELEASE
-      CMAKE_C_FLAGS_MINSIZEREL
-      CMAKE_C_FLAGS_RELWITHDEBINFO
-      CMAKE_CXX_FLAGS
-      CMAKE_CXX_FLAGS_DEBUG
-      CMAKE_CXX_FLAGS_RELEASE
-      CMAKE_CXX_FLAGS_MINSIZEREL
-      CMAKE_CXX_FLAGS_RELWITHDEBINFO
-    )
-      if(${flag} MATCHES "/MD")
-        string(REGEX REPLACE "/MD" "/MT" ${flag} "${${flag}}")
-      endif()
-      if(${flag} MATCHES "/MDd")
-        string(REGEX REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
-      endif()
-    endforeach()
+  if(USE_MSVC_RUNTIME_LIBRARY_DLL)
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
   else()
-    if(USE_MSVC_RUNTIME_LIBRARY_DLL)
-      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
-    else()
-      set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-    endif()
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
   endif()
 endif(MSVC)

--- a/include/mem3dg/solver/geometry.h
+++ b/include/mem3dg/solver/geometry.h
@@ -409,6 +409,25 @@ public:
   EigenVectorX1d computeGeodesicDistance();
 
   /**
+   * @brief Compute geodesic distances relative to a set of vertices
+   *
+   * @param points Set of vertices to get geodesic distances from
+   * @return EigenVectorX1d   Geodesic distances
+   */
+  EigenVectorX1d
+  computeGeodesicDistance(const std::vector<gcs::Vertex> &points) const;
+
+  /**
+   * @brief Compute geodesic distances relative to a set of vertices specified
+   * by index
+   *
+   * @param points Indices of notable vertices
+   * @return EigenVectorX1d Geodesic distances
+   */
+  EigenVectorX1d
+  computeGeodesicDistance(const std::vector<std::size_t> &points) const;
+
+  /**
    * @brief Get tangential derivative of quantities on face
    */
   void computeFaceTangentialDerivative(gcs::VertexData<double> &quantities,
@@ -419,6 +438,18 @@ public:
    */
   double computeLengthCrossRatio(gcs::VertexPositionGeometry &vpg,
                                  gcs::Halfedge &he) const;
+
+  inline gcs::Vertex vertex(const std::size_t i) const {
+    return mesh->vertex(i);
+  }
+
+  inline bool isBoundary(const std::size_t i) const {
+    return mesh->vertex(i).isBoundary();
+  }
+  inline bool isBoundary(const gcs::Vertex v) const { return v.isBoundary(); }
+  inline std::size_t nVertices() const { return mesh->nVertices(); }
+  inline std::size_t nEdges() const { return mesh->nEdges(); }
+  inline std::size_t nFaces() const { return mesh->nFaces(); }
 };
 } // namespace solver
 } // namespace mem3dg

--- a/include/mem3dg/solver/integrator/forward_euler.h
+++ b/include/mem3dg/solver/integrator/forward_euler.h
@@ -36,25 +36,18 @@ namespace integrator {
  */
 class DLL_PUBLIC Euler : public Integrator {
 public:
-  gcs::VertexData<gc::Vector3> pastMechanicalForceVec;
-  gcs::VertexData<gc::Vector3> past2MechanicalForceVec;
-
   Euler(System &system_, double characteristicTimeStep_, double totalTime_,
         double savePeriod_, double tolerance_, std::string outputDirectory_,
         std::size_t frame_ = 0)
       : Integrator(system_, characteristicTimeStep_, totalTime_, savePeriod_,
                    tolerance_, outputDirectory_, frame_) {
     // check the validity of parameter
-    pastMechanicalForceVec = system.forces.mechanicalForceVec;
-    past2MechanicalForceVec = pastMechanicalForceVec;
     checkParameters();
   }
   Euler(System &system_, double characteristicTimeStep_, double tolerance_,
         std::string outputDirectory_)
       : Integrator(system_, characteristicTimeStep_, tolerance_,
                    outputDirectory_) {
-    pastMechanicalForceVec = system.forces.mechanicalForceVec;
-    past2MechanicalForceVec = pastMechanicalForceVec;
     checkParameters();
   }
 

--- a/include/mem3dg/solver/integrator/forward_euler.h
+++ b/include/mem3dg/solver/integrator/forward_euler.h
@@ -36,18 +36,25 @@ namespace integrator {
  */
 class DLL_PUBLIC Euler : public Integrator {
 public:
+  gcs::VertexData<gc::Vector3> pastMechanicalForceVec;
+  gcs::VertexData<gc::Vector3> past2MechanicalForceVec;
+
   Euler(System &system_, double characteristicTimeStep_, double totalTime_,
         double savePeriod_, double tolerance_, std::string outputDirectory_,
         std::size_t frame_ = 0)
       : Integrator(system_, characteristicTimeStep_, totalTime_, savePeriod_,
                    tolerance_, outputDirectory_, frame_) {
     // check the validity of parameter
+    pastMechanicalForceVec = system.forces.mechanicalForceVec;
+    past2MechanicalForceVec = pastMechanicalForceVec;
     checkParameters();
   }
   Euler(System &system_, double characteristicTimeStep_, double tolerance_,
         std::string outputDirectory_)
       : Integrator(system_, characteristicTimeStep_, tolerance_,
                    outputDirectory_) {
+    pastMechanicalForceVec = system.forces.mechanicalForceVec;
+    past2MechanicalForceVec = pastMechanicalForceVec;
     checkParameters();
   }
 

--- a/include/mem3dg/solver/integrator/integrator.h
+++ b/include/mem3dg/solver/integrator/integrator.h
@@ -74,6 +74,8 @@ public:
   // key parameters (read/write)
   /// characteristic time step
   double characteristicTimeStep;
+  // Original time step at construction
+  double baseTimeStep;
   // total simulation time
   double totalTime = std::numeric_limits<double>::max();
   /// period of saving output data
@@ -132,7 +134,8 @@ public:
   Integrator(System &system_, double characteristicTimeStep_, double tolerance_,
              std::string outputDirectory_)
       : timeStep(characteristicTimeStep_), system(system_),
-        characteristicTimeStep(characteristicTimeStep_), tolerance(tolerance_),
+        characteristicTimeStep(characteristicTimeStep_),
+        baseTimeStep(characteristicTimeStep_), tolerance(tolerance_),
         outputDirectory(outputDirectory_) {
     ifDisableIntegrate = true;
     ifPrintToConsole = true;

--- a/include/mem3dg/solver/integrator/integrator.h
+++ b/include/mem3dg/solver/integrator/integrator.h
@@ -91,7 +91,8 @@ public:
   /// backtracking coefficient
   double rho = 0.7;
   /// Wolfe condition parameter
-  double c1 = 0.001;
+  // double c1 = 0.001;
+  double c1 = 0.1;
 
   // defaulted parameters (read/write)
   /// if just save geometry .ply file
@@ -139,10 +140,12 @@ public:
         outputDirectory(outputDirectory_) {
     ifDisableIntegrate = true;
     ifPrintToConsole = true;
-    // Initialize the timestep-meshsize ratio
+    // dt_size2_ratio =
+    //     characteristicTimeStep /
+    //     std::pow(system.geometry.vpg->edgeLengths.raw().minCoeff(), 2);
     dt_size2_ratio =
         characteristicTimeStep /
-        std::pow(system.geometry.vpg->edgeLengths.raw().minCoeff(), 2);
+        system.geometry.vpg->edgeLengths.raw().minCoeff();
 
     // Initialize the initial maxForce
     system.computeConservativeForcing();

--- a/include/mem3dg/solver/integrator/integrator.h
+++ b/include/mem3dg/solver/integrator/integrator.h
@@ -91,8 +91,7 @@ public:
   /// backtracking coefficient
   double rho = 0.7;
   /// Wolfe condition parameter
-  // double c1 = 0.001;
-  double c1 = 0.1;
+  double c1 = 0.001;
 
   // defaulted parameters (read/write)
   /// if just save geometry .ply file
@@ -140,12 +139,10 @@ public:
         outputDirectory(outputDirectory_) {
     ifDisableIntegrate = true;
     ifPrintToConsole = true;
-    // dt_size2_ratio =
-    //     characteristicTimeStep /
-    //     std::pow(system.geometry.vpg->edgeLengths.raw().minCoeff(), 2);
+    // Initialize the timestep-meshsize ratio
     dt_size2_ratio =
         characteristicTimeStep /
-        system.geometry.vpg->edgeLengths.raw().minCoeff();
+        std::pow(system.geometry.vpg->edgeLengths.raw().minCoeff(), 2);
 
     // Initialize the initial maxForce
     system.computeConservativeForcing();

--- a/include/mem3dg/solver/mesh_process.h
+++ b/include/mem3dg/solver/mesh_process.h
@@ -61,7 +61,7 @@ struct MeshProcessor {
    */
   struct MeshMutator {
     /// period of mesh mutation
-    std::size_t mutateMeshPeriod = std::numeric_limits<std::size_t>::max();
+    double mutateMeshPeriod = std::numeric_limits<double>::max();
 
     /// Whether edge flip
     bool isFlipEdge = false;

--- a/include/mem3dg/solver/parameters.h
+++ b/include/mem3dg/solver/parameters.h
@@ -162,7 +162,7 @@ struct Parameters {
     /// domain of shape variation
     double geodesicMask = -1;
     /// period of updating mask
-    std::size_t updateMaskPeriod = std::numeric_limits<std::size_t>::max();
+    double updateMaskPeriod = std::numeric_limits<double>::max();
 
     /**
      * @brief check parameter conflicts
@@ -175,11 +175,10 @@ struct Parameters {
     std::function<Eigen::Matrix<bool, Eigen::Dynamic, 1>(const Geometry &)>
         prescribeNotableVertex = NULL;
     /// period of updating geodesic distance from notableVertex calculation
-    std::size_t updateGeodesicsPeriod = std::numeric_limits<std::size_t>::max();
+    double updateGeodesicsPeriod = std::numeric_limits<double>::max();
     /// period of updating notable vertex based functional
     /// prescribeNotableVertex
-    std::size_t updateNotableVertexPeriod =
-        std::numeric_limits<std::size_t>::max();
+    double updateNotableVertexPeriod = std::numeric_limits<double>::max();
   };
 
   struct Protein {
@@ -190,8 +189,8 @@ struct Parameters {
                                  EigenVectorX1d)>
         prescribeProteinDensityDistribution = NULL;
     /// period of updating protein density distribution
-    std::size_t updateProteinDensityDistributionPeriod =
-        std::numeric_limits<std::size_t>::max();
+    double updateProteinDensityDistributionPeriod =
+        std::numeric_limits<double>::max();
   };
 
   struct Spring {

--- a/include/mem3dg/solver/parameters.h
+++ b/include/mem3dg/solver/parameters.h
@@ -172,8 +172,7 @@ struct Parameters {
 
   struct Point {
     /// prescription of center finding
-    std::function<Eigen::Matrix<bool, Eigen::Dynamic, 1>(
-        EigenVectorX3sr, EigenVectorX3dr, EigenVectorX1d)>
+    std::function<Eigen::Matrix<bool, Eigen::Dynamic, 1>(const Geometry &)>
         prescribeNotableVertex = NULL;
     /// period of updating geodesic distance from notableVertex calculation
     std::size_t updateGeodesicsPeriod = std::numeric_limits<std::size_t>::max();

--- a/include/mem3dg/solver/parameters.h
+++ b/include/mem3dg/solver/parameters.h
@@ -186,7 +186,8 @@ struct Parameters {
     /// interior point parameter for protein density
     double proteinInteriorPenalty = 0; // 1e-6
     /// prescription of protein density
-    std::function<EigenVectorX1d(double, EigenVectorX1d, EigenVectorX1d)>
+    std::function<EigenVectorX1d(const Geometry &, double, EigenVectorX1d,
+                                 EigenVectorX1d)>
         prescribeProteinDensityDistribution = NULL;
     /// period of updating protein density distribution
     std::size_t updateProteinDensityDistributionPeriod =

--- a/include/mem3dg/solver/system.h
+++ b/include/mem3dg/solver/system.h
@@ -650,6 +650,8 @@ public:
    */
   bool processSplitCollapseQueued();
 
+  bool removeLowValencyVertices(std::size_t degree = 4);
+
   /**
    * @brief global smoothing after mutation of the mesh
    * @param initStep initial guess of time step

--- a/include/mem3dg/type_utilities.h
+++ b/include/mem3dg/type_utilities.h
@@ -342,6 +342,10 @@ inline auto toMatrix(gcs::VertexData<gc::Vector3> &vector) {
   return gc::EigenMap<double, 3>(vector);
 }
 
+inline const auto toMatrix(const gcs::VertexData<gc::Vector3> &vector) {
+  return gc::EigenMap<double, 3>(vector);
+}
+
 } // namespace mem3dg
 
 namespace std {

--- a/libraries/CMakeLists.txt
+++ b/libraries/CMakeLists.txt
@@ -46,19 +46,16 @@ endif()
 # ##############################################################################
 # GET GEOMETRY CENTRAL
 # ##############################################################################
-# FetchContent_Declare( geometrycentrallib GIT_REPOSITORY
-# https://github.com/nmwsharp/geometry-central.git GIT_TAG origin/master
-# GIT_SHALLOW TRUE SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/geometrycentral-src"
-# BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/geometrycentral-build" )
-# FetchContent_GetProperties(geometrycentrallib) if(NOT
-# geometrycentrallib_POPULATED) FetchContent_Populate(geometrycentrallib)
-# add_subdirectory( ${geometrycentrallib_SOURCE_DIR}
-# ${geometrycentrallib_BINARY_DIR} ) set_target_properties( geometry-central
-# PROPERTIES POSITION_INDEPENDENT_CODE ON ) endif()
+
+
+
+set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+set(BUILD_SHARED_LIBS OFF)
 add_subdirectory(geometry-central EXCLUDE_FROM_ALL SYSTEM )
 set_target_properties(geometry-central PROPERTIES POSITION_INDEPENDENT_CODE ON)
+set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 # Suppress noise from sprintf deprecated
-target_compile_options(geometry-central PRIVATE "-Wno-deprecated-declarations")
+# target_compile_options(geometry-central PRIVATE "-Wno-deprecated-declarations")
 
 # ##############################################################################
 # Configure libigl

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ tests = ["pytest"]
 cmake.args = ["-DBUILD_PYMEM3DG=ON", "-DSUITESPARSE=OFF"]
 wheel.packages = ["python_src/pymem3dg"]
 metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
-install.components = ["PythonModule"]
+install.components = ["PythonModule", "Runtime"]
 install.strip = false
 
 

--- a/python_src/CMakeLists.txt
+++ b/python_src/CMakeLists.txt
@@ -21,7 +21,7 @@ if(M3DG_GET_OWN_PYBIND11)
   FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG v2.10.4
+    GIT_TAG v2.13.6
     GIT_SHALLOW TRUE
     SYSTEM SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/pybind11-src" BINARY_DIR
     "${CMAKE_CURRENT_BINARY_DIR}/pybind11-build"
@@ -30,16 +30,6 @@ if(M3DG_GET_OWN_PYBIND11)
 else()
   find_package(pybind11 REQUIRED CONFIG)
 endif()
-
-# mem3dg static library
-add_library(
-  mem3dg_static STATIC EXCLUDE_FROM_ALL $<TARGET_OBJECTS:mem3dg_objlib>
-)
-target_link_libraries(mem3dg_static PUBLIC mem3dg_objlib)
-set_target_properties(
-  mem3dg_static PROPERTIES POSITION_INDEPENDENT_CODE ON CXX_VISIBILITY_PRESET
-                                                        hidden
-)
 
 set(PYMEM3DG_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/pymem3dg.cpp"
@@ -53,7 +43,8 @@ set(PYMEM3DG_SOURCES
 )
 
 pybind11_add_module(_core MODULE ${PYMEM3DG_SOURCES})
-target_link_libraries(_core PRIVATE mem3dg_static)
+# target_link_libraries(_core PRIVATE mem3dg_static)
+target_link_libraries(_core PRIVATE mem3dg)
 
 if(WITH_NETCDF)
   target_compile_definitions(_core PUBLIC -DMEM3DG_WITH_NETCDF)

--- a/python_src/pymem3dg/__init__.pyi
+++ b/python_src/pymem3dg/__init__.pyi
@@ -2,18 +2,20 @@ import flags
 import numpy
 import scipy.sparse
 from _typeshed import Incomplete
-from typing import Callable, List, Tuple, overload
+from typing import Callable, overload
 
 __short_version__: str
 __version__: str
 
 class Adsorption:
     epsilon: float
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Aggregation:
     chi: float
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Bending:
     D: float
@@ -22,15 +24,19 @@ class Bending:
     Kbc: float
     Kd: float
     Kdc: float
+    Kg: float
+    Kgc: float
     alpha: float
     dA0: float
     relation: str
-    def __init__(self) -> None: ...
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.Bending) -> None"""
 
 class Boundary:
     proteinBoundaryCondition: str
     shapeBoundaryCondition: str
-    def __init__(self) -> None: ...
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.Boundary) -> None"""
 
 class ConjugateGradient:
     c1: float
@@ -55,14 +61,50 @@ class ConjugateGradient:
         tolerance: float,
         outputDirectory: str,
         frame: int = ...,
-    ) -> None: ...
-    def integrate(self) -> bool: ...
-    def march(self) -> None: ...
+    ) -> None:
+        """__init__(self: pymem3dg._core.ConjugateGradient, system: mem3dg::solver::System, characteristicTimeStep: float, totalTime: float, savePeriod: float, tolerance: float, outputDirectory: str, frame: int = 0) -> None
+
+
+        Conjugate Gradient optimizer constructor
+
+        """
+    def integrate(self) -> bool:
+        """integrate(self: pymem3dg._core.ConjugateGradient) -> bool
+
+
+        integrate
+
+        """
+    def march(self) -> None:
+        """march(self: pymem3dg._core.ConjugateGradient) -> None
+
+
+        stepping forward
+
+        """
     def saveData(
         self, ifOutputTrajFile: bool, ifOutputMeshFile: bool, ifPrintToConsole: bool
-    ) -> None: ...
-    def status(self) -> None: ...
-    def step(self, n: int) -> None: ...
+    ) -> None:
+        """saveData(self: pymem3dg._core.ConjugateGradient, ifOutputTrajFile: bool, ifOutputMeshFile: bool, ifPrintToConsole: bool) -> None
+
+
+        save data to output directory
+
+        """
+    def status(self) -> None:
+        """status(self: pymem3dg._core.ConjugateGradient) -> None
+
+
+        status computation and thresholding
+
+        """
+    def step(self, n: int) -> None:
+        """step(self: pymem3dg._core.ConjugateGradient, n: int) -> None
+
+
+        step for n iterations
+
+        """
     @property
     def characteristicTimeStep(self) -> float: ...
     @property
@@ -74,14 +116,17 @@ class ConjugateGradient:
 
 class DPD:
     gamma: float
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Dirichlet:
     eta: float
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Energy:
-    def __init__(self) -> None: ...
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.Energy) -> None"""
     @property
     def adsorptionEnergy(self) -> float: ...
     @property
@@ -119,7 +164,8 @@ class Energy:
 
 class Entropy:
     xi: float
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Euler:
     c1: float
@@ -142,7 +188,22 @@ class Euler:
         tolerance: float,
         outputDirectory: str,
         frame: int = ...,
-    ) -> None: ...
+    ) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.Euler, system: mem3dg::solver::System, characteristicTimeStep: float, totalTime: float, savePeriod: float, tolerance: float, outputDirectory: str, frame: int = 0) -> None
+
+
+                Euler integrator (steepest descent) constructor
+
+
+        2. __init__(self: pymem3dg._core.Euler, system: mem3dg::solver::System, characteristicTimeStep: float, tolerance: float, outputDirectory: str) -> None
+
+
+                Euler integrator (steepest descent) constructor
+
+        """
     @overload
     def __init__(
         self,
@@ -150,17 +211,80 @@ class Euler:
         characteristicTimeStep: float,
         tolerance: float,
         outputDirectory: str,
-    ) -> None: ...
-    def closeMutableNetcdfFile(self) -> None: ...
-    def createMutableNetcdfFile(self, isContinue: bool) -> None: ...
-    def integrate(self) -> bool: ...
-    def march(self) -> None: ...
+    ) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.Euler, system: mem3dg::solver::System, characteristicTimeStep: float, totalTime: float, savePeriod: float, tolerance: float, outputDirectory: str, frame: int = 0) -> None
+
+
+                Euler integrator (steepest descent) constructor
+
+
+        2. __init__(self: pymem3dg._core.Euler, system: mem3dg::solver::System, characteristicTimeStep: float, tolerance: float, outputDirectory: str) -> None
+
+
+                Euler integrator (steepest descent) constructor
+
+        """
+    def closeMutableNetcdfFile(self) -> None:
+        """closeMutableNetcdfFile(self: pymem3dg._core.Euler) -> None
+
+
+        close netcdf file
+
+        """
+    def createMutableNetcdfFile(self, isContinue: bool) -> None:
+        """createMutableNetcdfFile(self: pymem3dg._core.Euler, isContinue: bool) -> None
+
+
+        create netcdf file
+
+        """
+    def integrate(self) -> bool:
+        """integrate(self: pymem3dg._core.Euler) -> bool
+
+
+        integrate
+
+        """
+    def march(self) -> None:
+        """march(self: pymem3dg._core.Euler) -> None
+
+
+        stepping forward
+
+        """
     def saveData(
         self, ifOutputTrajFile: bool, ifOutputMeshFile: bool, ifPrintToConsole: bool
-    ) -> None: ...
-    def saveMutableNetcdfData(self) -> None: ...
-    def status(self) -> None: ...
-    def step(self, n: int) -> None: ...
+    ) -> None:
+        """saveData(self: pymem3dg._core.Euler, ifOutputTrajFile: bool, ifOutputMeshFile: bool, ifPrintToConsole: bool) -> None
+
+
+        save data to output directory
+
+        """
+    def saveMutableNetcdfData(self) -> None:
+        """saveMutableNetcdfData(self: pymem3dg._core.Euler) -> None
+
+
+        write to netcdf file
+
+        """
+    def status(self) -> None:
+        """status(self: pymem3dg._core.Euler) -> None
+
+
+        status computation and thresholding
+
+        """
+    def step(self, n: int) -> None:
+        """step(self: pymem3dg._core.Euler, n: int) -> None
+
+
+        step for n iterations
+
+        """
     @property
     def EXIT(self) -> bool: ...
     @property
@@ -184,128 +308,637 @@ class External:
         ],
         numpy.ndarray[numpy.float64[m, 3]],
     ]
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Forces:
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
     def getAdsorptionForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getAdsorptionPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getAdsorptionForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the adsorption force
+
+        """
+    def getAdsorptionPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getAdsorptionPotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the adsorption potential
+
+        """
     def getAggregationForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getAggregationPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getAggregationForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the aggregation force
+
+        """
+    def getAggregationPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getAggregationPotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the aggregation potential
+
+        """
     def getAreaDifferenceForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getAreaDifferenceForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the area difference force of the system
+
+        """
     def getCapillaryForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getChemicalPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getCapillaryForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the tension-induced capillary Force
+
+        """
+    def getChemicalPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getChemicalPotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the chemical Potential
+
+        """
     def getDeviatoricCurvatureForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getDeviatoricCurvaturePotential(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def getDirichletPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getDeviatoricCurvatureForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the deviatoric curvature force of the system
+
+        """
+    def getDeviatoricCurvaturePotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getDeviatoricCurvaturePotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the deviatoric curvature potential
+
+        """
+    def getDirichletPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getDirichletPotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the dirichlet Potential
+
+        """
     def getEntropyForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getEntropyPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getEntropyForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the entropy force
+
+        """
+    def getEntropyPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getEntropyPotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the entropy Potential
+
+        """
     def getExternalForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getInteriorPenaltyPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getExternalForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the externally-applied Force
+
+        """
+    def getInteriorPenaltyPotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getInteriorPenaltyPotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the interior point potential
+
+        """
     def getLineCapillaryForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getLineCapillaryForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the interfacial line tension
+
+        """
     def getMechanicalForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getMechanicalForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the the total mechanical force
+
+        """
     def getOsmoticForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getOsmoticPressure(self) -> float: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getOsmoticForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the osmotic force
+
+        """
+    def getOsmoticPressure(self) -> float:
+        """getOsmoticPressure(self: pymem3dg._core.Forces) -> float
+
+
+        get the osmotic pressure
+
+        """
     def getSpontaneousCurvatureForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getSpontaneousCurvatureForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the spontaneous curvature force of the system
+
+        """
     def getSpontaneousCurvatureForceVec_areaGrad(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getSpontaneousCurvatureForceVec_areaGrad(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the area gradient component of the spontaneous curvature force of the system
+
+        """
     def getSpontaneousCurvatureForceVec_gaussVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getSpontaneousCurvatureForceVec_gaussVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the the gaussian curvature vector component of the spontaneous curvature force of the system
+
+        """
     def getSpontaneousCurvatureForceVec_schlafliVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getSpontaneousCurvaturePotential(
-        self,
-    ) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getSpontaneousCurvatureForceVec_schlafliVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the Schlaflic (smoothing) component of the spontaneous curvature force of the system
+
+        """
+    def getSpontaneousCurvaturePotential(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getSpontaneousCurvaturePotential(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the spontaneous curvature potential
+
+        """
     def getSpringForceVec(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getSurfaceTension(self) -> float: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getSpringForceVec(self: pymem3dg._core.Forces) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the spring force
+
+        """
+    def getSurfaceTension(self) -> float:
+        """getSurfaceTension(self: pymem3dg._core.Forces) -> float
+
+
+        get the Surface tension
+
+        """
 
 class Geometry:
     @overload
     def __init__(
         self, inputMesh: str, notableVertex: numpy.ndarray[bool[m, 1]]
-    ) -> None: ...
+    ) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.Geometry, inputMesh: str, notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with .ply files.
+
+
+        2. __init__(self: pymem3dg._core.Geometry, inputMesh: str) -> None
+
+
+                  Geometry constructor with .ply files.
+
+
+        3. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]], notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        4. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        5. __init__(self: pymem3dg._core.Geometry, trajFile: str, startingFrame: int) -> None
+
+
+                Geometry constructor with NetCDF trajectory file
+
+        """
     @overload
-    def __init__(self, inputMesh: str) -> None: ...
+    def __init__(self, inputMesh: str) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.Geometry, inputMesh: str, notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with .ply files.
+
+
+        2. __init__(self: pymem3dg._core.Geometry, inputMesh: str) -> None
+
+
+                  Geometry constructor with .ply files.
+
+
+        3. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]], notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        4. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        5. __init__(self: pymem3dg._core.Geometry, trajFile: str, startingFrame: int) -> None
+
+
+                Geometry constructor with NetCDF trajectory file
+
+        """
     @overload
     def __init__(
         self,
         faceMatrix: numpy.ndarray[numpy.uint64[m, 3]],
         vertexMatrix: numpy.ndarray[numpy.float64[m, 3]],
         notableVertex: numpy.ndarray[bool[m, 1]],
-    ) -> None: ...
+    ) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.Geometry, inputMesh: str, notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with .ply files.
+
+
+        2. __init__(self: pymem3dg._core.Geometry, inputMesh: str) -> None
+
+
+                  Geometry constructor with .ply files.
+
+
+        3. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]], notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        4. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        5. __init__(self: pymem3dg._core.Geometry, trajFile: str, startingFrame: int) -> None
+
+
+                Geometry constructor with NetCDF trajectory file
+
+        """
     @overload
     def __init__(
         self,
         faceMatrix: numpy.ndarray[numpy.uint64[m, 3]],
         vertexMatrix: numpy.ndarray[numpy.float64[m, 3]],
-    ) -> None: ...
+    ) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.Geometry, inputMesh: str, notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with .ply files.
+
+
+        2. __init__(self: pymem3dg._core.Geometry, inputMesh: str) -> None
+
+
+                  Geometry constructor with .ply files.
+
+
+        3. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]], notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        4. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        5. __init__(self: pymem3dg._core.Geometry, trajFile: str, startingFrame: int) -> None
+
+
+                Geometry constructor with NetCDF trajectory file
+
+        """
     @overload
-    def __init__(self, trajFile: str, startingFrame: int) -> None: ...
-    def computeGeodesicDistance(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def getCotanLaplacian(self) -> scipy.sparse.csc_matrix[numpy.float64]: ...
-    def getEdgeAdjacencyMatrix(self) -> scipy.sparse.csc_matrix[numpy.float64]: ...
-    def getEdgeLengths(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def getFaceAreas(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def getFaceMatrix(self) -> numpy.ndarray[numpy.uint64[m, n]]: ...
-    def getGeodesicDistance(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def getLumpedMassMatrix(self) -> scipy.sparse.csc_matrix[numpy.float64]: ...
-    def getNotableVertex(self) -> numpy.ndarray[bool[m, 1]]: ...
-    def getPolyscopeEdgeOrientations(self) -> numpy.ndarray[numpy.int8[m, 1]]: ...
-    def getPolyscopePermutations(self) -> List[None]: ...
-    def getSurfaceArea(self) -> float: ...
-    def getVertexAdjacencyMatrix(self) -> scipy.sparse.csc_matrix[numpy.float64]: ...
-    def getVertexDualAreas(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    def __init__(self, trajFile: str, startingFrame: int) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.Geometry, inputMesh: str, notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with .ply files.
+
+
+        2. __init__(self: pymem3dg._core.Geometry, inputMesh: str) -> None
+
+
+                  Geometry constructor with .ply files.
+
+
+        3. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]], notableVertex: numpy.ndarray[bool[m, 1]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        4. __init__(self: pymem3dg._core.Geometry, faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]]) -> None
+
+
+                Geometry constructor with Matrices
+
+
+        5. __init__(self: pymem3dg._core.Geometry, trajFile: str, startingFrame: int) -> None
+
+
+                Geometry constructor with NetCDF trajectory file
+
+        """
+    @overload
+    def computeGeodesicDistance(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """computeGeodesicDistance(*args, **kwargs)
+        Overloaded function.
+
+        1. computeGeodesicDistance(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+                  compute the geodesic distance centered around Center cached in System
+
+                  return: NDarray[double]
+
+
+        2. computeGeodesicDistance(self: pymem3dg._core.Geometry, points: list[int]) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+                    compute the geodesic distance from a set of vertex indices
+
+                    return: NDarray[double]
+
+        """
+    @overload
+    def computeGeodesicDistance(
+        self, points: list[int]
+    ) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """computeGeodesicDistance(*args, **kwargs)
+        Overloaded function.
+
+        1. computeGeodesicDistance(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+                  compute the geodesic distance centered around Center cached in System
+
+                  return: NDarray[double]
+
+
+        2. computeGeodesicDistance(self: pymem3dg._core.Geometry, points: list[int]) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+                    compute the geodesic distance from a set of vertex indices
+
+                    return: NDarray[double]
+
+        """
+    def getCotanLaplacian(self) -> scipy.sparse.csc_matrix[numpy.float64]:
+        """getCotanLaplacian(self: pymem3dg._core.Geometry) -> scipy.sparse.csc_matrix[numpy.float64]
+
+
+        get the Cotan Laplacian matrix of the mesh
+
+        """
+    def getEdgeAdjacencyMatrix(self) -> scipy.sparse.csc_matrix[numpy.float64]:
+        """getEdgeAdjacencyMatrix(self: pymem3dg._core.Geometry) -> scipy.sparse.csc_matrix[numpy.float64]
+
+
+        get the signed F-E edge adjacency matrix, equivalent of d1 operator
+
+        """
+    def getEdgeLengths(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getEdgeLengths(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get edge lengths
+
+        """
+    def getFaceAreas(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getFaceAreas(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get face area
+
+        """
+    def getFaceMatrix(self) -> numpy.ndarray[numpy.uint64[m, n]]:
+        """getFaceMatrix(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.uint64[m, n]]
+
+
+        get the face matrix
+
+        """
+    def getGeodesicDistance(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getGeodesicDistance(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the geodesic distance from notable vertices of the mesh
+
+        """
+    def getLumpedMassMatrix(self) -> scipy.sparse.csc_matrix[numpy.float64]:
+        """getLumpedMassMatrix(self: pymem3dg._core.Geometry) -> scipy.sparse.csc_matrix[numpy.float64]
+
+
+        get the lumped mass matrix of the mesh
+
+        """
+    def getNotableVertex(self) -> numpy.ndarray[bool[m, 1]]:
+        """getNotableVertex(self: pymem3dg._core.Geometry) -> numpy.ndarray[bool[m, 1]]
+
+
+        get vertex data to track the notable vertex, which may or may not be a single vertex
+
+        """
+    def getPolyscopeEdgeOrientations(self) -> numpy.ndarray[numpy.int8[m, 1]]:
+        """getPolyscopeEdgeOrientations(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.int8[m, 1]]
+
+
+        get polyscope edge orientation
+
+        """
+    def getPolyscopePermutations(self, *args, **kwargs):
+        """getPolyscopePermutations(self: pymem3dg._core.Geometry) -> Annotated[list[tuple[list[int], int]], FixedSize(5)]
+
+
+        get polyscope permutation
+
+        """
+    def getSurfaceArea(self) -> float:
+        """getSurfaceArea(self: pymem3dg._core.Geometry) -> float
+
+
+        get the surface area of the mesh
+
+        """
+    def getVertexAdjacencyMatrix(self) -> scipy.sparse.csc_matrix[numpy.float64]:
+        """getVertexAdjacencyMatrix(self: pymem3dg._core.Geometry) -> scipy.sparse.csc_matrix[numpy.float64]
+
+
+        get the signed E-V vertex adjacency matrix, equivalent of d0 operator
+
+        """
+    def getVertexDualAreas(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getVertexDualAreas(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get vertex dual area
+
+        """
     def getVertexGaussianCurvatureVectors(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getVertexGaussianCurvatures(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getVertexGaussianCurvatureVectors(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the integrated vector Gaussian Curvature
+
+        """
+    def getVertexGaussianCurvatures(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getVertexGaussianCurvatures(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the integrated scalar Gaussian Curvature
+
+        """
     def getVertexMatrix(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getVertexMatrix(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the vertex matrix
+
+        """
     def getVertexMeanCurvatureVectors(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getVertexMeanCurvatures(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getVertexMeanCurvatureVectors(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the integrated vector Mean Curvature
+
+        """
+    def getVertexMeanCurvatures(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getVertexMeanCurvatures(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        get the integrated scalar mean curvature
+
+        """
     def getVertexNormals(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getVertexNormals(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get angle-weighted normal on vertices
+
+        """
     def getVertexSchlafliLaplacianMeanCurvatureVectors(
         self, arg0: numpy.ndarray[numpy.float64[m, 1]]
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getVertexSchlafliLaplacianMeanCurvatureVectors(self: pymem3dg._core.Geometry, arg0: numpy.ndarray[numpy.float64[m, 1]]) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the vertex Schlafli based Laplacian of mean curvature Vectors
+
+        """
     def getVertexVolumeVariationVectors(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def getVolume(self) -> float: ...
-    def setInputVertexPositions(
-        self, arg0: numpy.ndarray[numpy.float64[m, 3]]
-    ) -> None: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getVertexVolumeVariationVectors(self: pymem3dg._core.Geometry) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+
+        get the integrated vector volume variation (dual area)
+
+        """
+    def getVolume(self) -> float:
+        """getVolume(self: pymem3dg._core.Geometry) -> float
+
+
+        get the enclosed volume of the mesh
+
+        """
+    def isBoundary(self, index: int) -> bool:
+        """isBoundary(self: pymem3dg._core.Geometry, index: int) -> bool
+
+
+        check if the vertex is on the boundary
+
+        return: bool
+
+        """
+    def nEdges(self) -> int:
+        """nEdges(self: pymem3dg._core.Geometry) -> int"""
+    def nFaces(self) -> int:
+        """nFaces(self: pymem3dg._core.Geometry) -> int"""
+    def nVertices(self) -> int:
+        """nVertices(self: pymem3dg._core.Geometry) -> int"""
+    def setInputVertexPositions(self, arg0: numpy.ndarray[numpy.float64[m, 3]]) -> None:
+        """setInputVertexPositions(self: pymem3dg._core.Geometry, arg0: numpy.ndarray[numpy.float64[m, 3]]) -> None
+
+
+        set the vertex matrix
+
+        """
 
 class MeshMutator:
     collapseFlat: bool
@@ -329,7 +962,13 @@ class MeshMutator:
     splitLong: bool
     splitSharp: bool
     splitSkinnyDelaunay: bool
-    def __init__(self) -> None: ...
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.MeshMutator) -> None
+
+
+        Constructor of mesh mutator object
+
+        """
     @property
     def isChangeTopology(self) -> bool: ...
     @property
@@ -341,13 +980,20 @@ class MeshMutator:
 
 class MeshProcessor:
     meshMutator: MeshMutator
-    def __init__(self) -> None: ...
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.MeshProcessor) -> None
+
+
+        MeshProcessor constructor
+
+        """
     @property
     def isMeshMutate(self) -> bool: ...
 
 class Osmotic:
-    form: Callable[[float], Tuple[float, float]]
-    def __init__(self, *args, **kwargs) -> None: ...
+    form: Callable[[float], tuple[float, float]]
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Parameters:
     adsorption: Adsorption
@@ -368,36 +1014,38 @@ class Parameters:
     temperature: float
     tension: Tension
     variation: Variation
-    def __init__(self) -> None: ...
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.Parameters) -> None"""
 
 class Point:
-    prescribeNotableVertex: Callable[
-        [
-            numpy.ndarray[numpy.uint64[m, 3]],
-            numpy.ndarray[numpy.float64[m, 3]],
-            numpy.ndarray[numpy.float64[m, 1]],
-        ],
-        numpy.ndarray[bool[m, 1]],
-    ]
-    updateGeodesicsPeriod: int
-    updateNotableVertexPeriod: int
-    def __init__(self, *args, **kwargs) -> None: ...
+    prescribeNotableVertex: Callable[[Geometry], numpy.ndarray[bool[m, 1]]]
+    updateGeodesicsPeriod: float
+    updateNotableVertexPeriod: float
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class Protein:
     prescribeProteinDensityDistribution: Callable[
-        [float, numpy.ndarray[numpy.float64[m, 1]], numpy.ndarray[numpy.float64[m, 1]]],
+        [
+            Geometry,
+            float,
+            numpy.ndarray[numpy.float64[m, 1]],
+            numpy.ndarray[numpy.float64[m, 1]],
+        ],
         numpy.ndarray[numpy.float64[m, 1]],
     ]
     proteinInteriorPenalty: float
-    updateProteinDensityDistributionPeriod: int
-    def __init__(self, *args, **kwargs) -> None: ...
+    updateProteinDensityDistributionPeriod: float
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class SelfAvoidance:
     d: float
     mu: float
     n: int
     p: float
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 class System:
     meshProcessor: MeshProcessor
@@ -411,50 +1059,245 @@ class System:
         velocity: numpy.ndarray[numpy.float64[m, 3]],
         parameters,
         time: float = ...,
-    ) -> None: ...
+    ) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, proteinDensity: numpy.ndarray[numpy.float64[m, 1]], velocity: numpy.ndarray[numpy.float64[m, 3]], parameters: mem3dg::solver::Parameters, time: float = 0) -> None
+
+
+                System constructor with Matrices
+
+
+        2. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, parameters: mem3dg::solver::Parameters, time: float = 0) -> None
+
+
+                System constructor with Matrices
+
+
+        3. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, trajFile: str, startingFrame: int, parameters: mem3dg::solver::Parameters) -> None
+
+
+                System constructor with NetCDF trajectory file
+
+        """
     @overload
-    def __init__(self, geometry: Geometry, parameters, time: float = ...) -> None: ...
+    def __init__(self, geometry: Geometry, parameters, time: float = ...) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, proteinDensity: numpy.ndarray[numpy.float64[m, 1]], velocity: numpy.ndarray[numpy.float64[m, 3]], parameters: mem3dg::solver::Parameters, time: float = 0) -> None
+
+
+                System constructor with Matrices
+
+
+        2. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, parameters: mem3dg::solver::Parameters, time: float = 0) -> None
+
+
+                System constructor with Matrices
+
+
+        3. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, trajFile: str, startingFrame: int, parameters: mem3dg::solver::Parameters) -> None
+
+
+                System constructor with NetCDF trajectory file
+
+        """
     @overload
     def __init__(
         self, geometry: Geometry, trajFile: str, startingFrame: int, parameters
-    ) -> None: ...
-    def addNonconservativeForcing(self, timeStep: float = ...) -> None: ...
-    def computeConservativeForcing(self) -> None: ...
+    ) -> None:
+        """__init__(*args, **kwargs)
+        Overloaded function.
+
+        1. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, proteinDensity: numpy.ndarray[numpy.float64[m, 1]], velocity: numpy.ndarray[numpy.float64[m, 3]], parameters: mem3dg::solver::Parameters, time: float = 0) -> None
+
+
+                System constructor with Matrices
+
+
+        2. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, parameters: mem3dg::solver::Parameters, time: float = 0) -> None
+
+
+                System constructor with Matrices
+
+
+        3. __init__(self: pymem3dg._core.System, geometry: pymem3dg._core.Geometry, trajFile: str, startingFrame: int, parameters: mem3dg::solver::Parameters) -> None
+
+
+                System constructor with NetCDF trajectory file
+
+        """
+    def addNonconservativeForcing(self, timeStep: float = ...) -> None:
+        """addNonconservativeForcing(self: pymem3dg._core.System, timeStep: float = 0) -> None
+
+
+        Compute and append all non-conservative forces, update mechanicalForce(Vec) and mechErrorNorm
+
+        """
+    def computeConservativeForcing(self) -> None:
+        """computeConservativeForcing(self: pymem3dg._core.System) -> None
+
+
+        Compute and update all conservative forces, update mechanicalForce(Vec) with conservativeForce(Vec)
+
+        """
     def computeInPlaneFluxForm(
         self, chemicalPotential: numpy.ndarray[numpy.float64[m, 1]]
-    ) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def computeIntegratedPower(self, dt: float) -> float: ...
-    def computeTotalEnergy(self) -> float: ...
-    def getEnergy(self, *args, **kwargs): ...
-    def getForces(self) -> Forces: ...
-    def getGeometry(self) -> Geometry: ...
-    def getProteinDensity(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def getProteinRateOfChange(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-    def getSpontaneousCurvature(self) -> numpy.ndarray[numpy.float64[m, 1]]: ...
+    ) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """computeInPlaneFluxForm(self: pymem3dg._core.System, chemicalPotential: numpy.ndarray[numpy.float64[m, 1]]) -> numpy.ndarray[numpy.float64[m, 1]]
+
+
+        Compute in plane flux form from chemical potential
+
+        Args:
+            chemicalPotential (npt.NDArray[np.float64]): components (or sum) of chemical potential
+
+        Returns
+            np.NDArray[np.float64]: in plane flux form on edges
+
+        """
+    def computeIntegratedPower(self, dt: float) -> float:
+        """computeIntegratedPower(self: pymem3dg._core.System, dt: float) -> float
+
+
+        Intermediate function to integrate the power
+
+        """
+    def computeTotalEnergy(self) -> float:
+        """computeTotalEnergy(self: pymem3dg._core.System) -> float
+
+
+        compute the total energy, where total energy = kinetic energy + potential energy - external work
+
+        """
+    def getEnergy(self, *args, **kwargs):
+        """getEnergy(self: pymem3dg._core.System) -> mem3dg::solver::Energy
+
+
+        Get the energy
+
+        Args:
+            System (:py:class:`System`): System of interest
+
+        Returns:
+            :py:class:`float`: Energy
+
+        """
+    def getForces(self) -> Forces:
+        """getForces(self: pymem3dg._core.System) -> pymem3dg._core.Forces
+
+
+        Get the pointwise forces
+
+        Args:
+            System (:py:class:`System`): System of interest
+
+        Returns:
+            :py:class:`pymem3dg.Forces`: Forces
+
+        """
+    def getGeometry(self) -> Geometry:
+        """getGeometry(self: pymem3dg._core.System) -> pymem3dg._core.Geometry
+
+
+        Get the geometry
+
+        Args:
+            System (:py:class:`System`): System of interest
+
+        Returns:
+            :py:class:`pymem3dg.Geometry`: Geometry
+
+        """
+    def getProteinDensity(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getProteinDensity(self: pymem3dg._core.System) -> numpy.ndarray[numpy.float64[m, 1]]
+
+        get the protein Density
+        """
+    def getProteinRateOfChange(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getProteinRateOfChange(self: pymem3dg._core.System) -> numpy.ndarray[numpy.float64[m, 1]]
+
+        get the protein rate of change
+        """
+    def getSpontaneousCurvature(self) -> numpy.ndarray[numpy.float64[m, 1]]:
+        """getSpontaneousCurvature(self: pymem3dg._core.System) -> numpy.ndarray[numpy.float64[m, 1]]
+
+        get the pointwise spontaneous curvature
+        """
     def getVelocity(
         self,
-    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]: ...
-    def initialize(self, ifMutateMesh: bool = ...) -> None: ...
-    def mutateMesh(self, nMutation: int = ...) -> None: ...
-    def prescribeExternalForce(self) -> numpy.ndarray[numpy.float64[m, 3]]: ...
-    def saveRichData(self, pathToSave: str, isJustGeometry: bool = ...) -> None: ...
+    ) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]:
+        """getVelocity(self: pymem3dg._core.System) -> numpy.ndarray[numpy.float64[m, 3], flags.writeable, flags.c_contiguous]
+
+        get the vertex velocity matrix
+        """
+    def initialize(self, ifMutateMesh: bool = ...) -> None:
+        """initialize(self: pymem3dg._core.System, ifMutateMesh: bool = False) -> None
+
+
+        initialize the system
+
+        """
+    def mutateMesh(self, nMutation: int = ...) -> None:
+        """mutateMesh(self: pymem3dg._core.System, nMutation: int = 1) -> None
+
+
+        mutate the mesh
+
+        """
+    def prescribeExternalForce(self) -> numpy.ndarray[numpy.float64[m, 3]]:
+        """prescribeExternalForce(self: pymem3dg._core.System) -> numpy.ndarray[numpy.float64[m, 3]]
+
+
+        prescribe the External Force
+
+        """
+    def saveRichData(self, pathToSave: str, isJustGeometry: bool = ...) -> None:
+        """saveRichData(self: pymem3dg._core.System, pathToSave: str, isJustGeometry: bool = False) -> None
+
+
+        save snapshot data to directory
+
+        """
     def smoothenMesh(
         self, initStep: float, target: float, maxIteration: int
-    ) -> numpy.ndarray[bool[m, 1]]: ...
-    def testConservativeForcing(self, timeStep: float) -> bool: ...
-    def updateConfigurations(self) -> None: ...
+    ) -> numpy.ndarray[bool[m, 1]]:
+        """smoothenMesh(self: pymem3dg._core.System, initStep: float, target: float, maxIteration: int) -> numpy.ndarray[bool[m, 1]]
+
+
+        smoothen the mesh using spontaneous curvature force
+
+        """
+    def testConservativeForcing(self, timeStep: float) -> bool:
+        """testConservativeForcing(self: pymem3dg._core.System, timeStep: float) -> bool
+
+
+        test conservative force computation by validating energy decrease
+
+        """
+    def updateConfigurations(self) -> None:
+        """updateConfigurations(self: pymem3dg._core.System) -> None
+
+
+        update the system configuration due to changes in state variables (e.g vertex positions or protein density)
+
+        """
 
 class Tension:
-    form: Callable[[float], Tuple[float, float]]
-    def __init__(self) -> None: ...
+    form: Callable[[float], tuple[float, float]]
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.Tension) -> None"""
 
 class Variation:
     geodesicMask: float
     isProteinConservation: bool
     isProteinVariation: bool
     isShapeVariation: bool
-    updateMaskPeriod: int
-    def __init__(self) -> None: ...
+    updateMaskPeriod: float
+    def __init__(self) -> None:
+        """__init__(self: pymem3dg._core.Variation) -> None"""
 
 class VelocityVerlet:
     c1: float
@@ -476,20 +1319,57 @@ class VelocityVerlet:
         tolerance: float,
         outputDirectory: str,
         frame: int = ...,
-    ) -> None: ...
-    def integrate(self) -> bool: ...
-    def march(self) -> None: ...
+    ) -> None:
+        """__init__(self: pymem3dg._core.VelocityVerlet, system: mem3dg::solver::System, characteristicTimeStep: float, totalTime: float, savePeriod: float, tolerance: float, outputDirectory: str, frame: int = 0) -> None
+
+
+        Velocity Verlet integrator constructor
+
+        """
+    def integrate(self) -> bool:
+        """integrate(self: pymem3dg._core.VelocityVerlet) -> bool
+
+
+        integrate
+
+        """
+    def march(self) -> None:
+        """march(self: pymem3dg._core.VelocityVerlet) -> None
+
+
+        stepping forward
+
+        """
     def saveData(
         self, ifOutputTrajFile: bool, ifOutputMeshFile: bool, ifPrintToConsole: bool
-    ) -> None: ...
-    def status(self) -> None: ...
-    def step(self, n: int) -> None: ...
+    ) -> None:
+        """saveData(self: pymem3dg._core.VelocityVerlet, ifOutputTrajFile: bool, ifOutputMeshFile: bool, ifPrintToConsole: bool) -> None
+
+
+        save data to output directory
+
+        """
+    def status(self) -> None:
+        """status(self: pymem3dg._core.VelocityVerlet) -> None
+
+
+        status computation and thresholding
+
+        """
+    def step(self, n: int) -> None:
+        """step(self: pymem3dg._core.VelocityVerlet, n: int) -> None
+
+
+        step for n iterations
+
+        """
 
 class spring:
     Kse: float
     Ksl: float
     Kst: float
-    def __init__(self, *args, **kwargs) -> None: ...
+    def __init__(self, *args, **kwargs) -> None:
+        """Initialize self.  See help(type(self)) for accurate signature."""
 
 def getCylinder(
     radius: float,
@@ -497,56 +1377,144 @@ def getCylinder(
     axialSubdivision: int,
     frequency: float = ...,
     amplitude: float = ...,
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """getCylinder(radius: float, radialSubdivision: int, axialSubdivision: int, frequency: float = 1, amplitude: float = 0) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+    get face and vertex matrix of a non-capped cylinder
+    """
+
 def getData(
     plyName: str, elementName: str, propertyName: str
-) -> numpy.ndarray[numpy.float64[m, 1]]: ...
-def getDataElementName(plyName: str) -> List[str]: ...
-def getDataPropertyName(plyName: str, elementName: str) -> List[str]: ...
+) -> numpy.ndarray[numpy.float64[m, 1]]:
+    """getData(plyName: str, elementName: str, propertyName: str) -> numpy.ndarray[numpy.float64[m, 1]]
+
+    read richData from .ply file
+
+    """
+
+def getDataElementName(plyName: str) -> list[str]:
+    """getDataElementName(plyName: str) -> list[str]
+
+    retrieve all richData element name from .ply file. Namely the list of the places where data live in, such as vertex, edge or face.
+
+    """
+
+def getDataPropertyName(plyName: str, elementName: str) -> list[str]:
+    """getDataPropertyName(plyName: str, elementName: str) -> list[str]
+
+    retrieve all richData property name from .ply file. Namely the list of the data where data on the particular element, such as vertex, edge or face.
+
+    """
+
 def getDiamond(
     dihedral: float,
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """getDiamond(dihedral: float) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+    get face and vertex matrix of diamond
+    """
+
 def getFaceAndVertexMatrix(
     plyName: str,
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
-def getFaceSurfacePointClosestToEmbeddedCoordinate(
-    faceMatrix: numpy.ndarray[numpy.uint64[m, 3]],
-    vertexMatrix: numpy.ndarray[numpy.float64[m, 3]],
-    embeddedCoordinate: List[float[3]],
-    filter: numpy.ndarray[bool[m, 1]],
-    accountedCoordinate: List[bool[3]] = ...,
-) -> Tuple[int, List[float[3]]]: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """getFaceAndVertexMatrix(plyName: str) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+
+    read face matrix and vertex matrix from .ply file
+
+    """
+
+def getFaceSurfacePointClosestToEmbeddedCoordinate(*args, **kwargs):
+    """getFaceSurfacePointClosestToEmbeddedCoordinate(faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]], embeddedCoordinate: Annotated[list[float], FixedSize(3)], filter: numpy.ndarray[bool[m, 1]], accountedCoordinate: Annotated[list[bool], FixedSize(3)] = [True, True, True]) -> tuple[int, Annotated[list[float], FixedSize(3)]]
+
+    find the face surface point closest to a embedded coordinate
+    """
+
 def getHexagon(
     radius: float, subdivision: int = ...
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """getHexagon(radius: float, subdivision: int = 0) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+    get face and vertex matrix of Hexagon
+    """
+
 def getIcosphere(
     radius: float, subdivision: int = ...
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """getIcosphere(radius: float, subdivision: int = 0) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+    get face and vertex matrix of icosphere
+    """
+
 def getTetrahedron() -> (
-    Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
-): ...
+    tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+):
+    """getTetrahedron() -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+    get face and vertex matrix of tetrahedron
+    """
+
 def getVertexClosestToEmbeddedCoordinate(
     vertexMatrix: numpy.ndarray[numpy.float64[m, 3]],
-    embeddedCoordinate: List[float[3]],
+    embeddedCoordinate,
     filter: numpy.ndarray[bool[m, 1]],
-    accountedCoordinate: List[bool[3]] = ...,
-) -> int: ...
+    accountedCoordinate=...,
+) -> int:
+    """getVertexClosestToEmbeddedCoordinate(vertexMatrix: numpy.ndarray[numpy.float64[m, 3]], embeddedCoordinate: Annotated[list[float], FixedSize(3)], filter: numpy.ndarray[bool[m, 1]], accountedCoordinate: Annotated[list[bool], FixedSize(3)] = [True, True, True]) -> int
+
+    find the index of vertex closest to a embedded coordinate
+    """
+
 def getVertexFurthestFromBoundary(
     faceMatrix: numpy.ndarray[numpy.uint64[m, 3]],
     vertexMatrix: numpy.ndarray[numpy.float64[m, 3]],
-) -> int: ...
+) -> int:
+    """getVertexFurthestFromBoundary(faceMatrix: numpy.ndarray[numpy.uint64[m, 3]], vertexMatrix: numpy.ndarray[numpy.float64[m, 3]]) -> int
+
+    find the vertex furthest away from the boundaries
+    """
+
 def linearSubdivide(
     face: numpy.ndarray[numpy.uint64[m, 3]],
     vertex: numpy.ndarray[numpy.float64[m, 3]],
     nSub: int,
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """linearSubdivide(face: numpy.ndarray[numpy.uint64[m, 3]], vertex: numpy.ndarray[numpy.float64[m, 3]], nSub: int) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+
+    subdivide the mesh with linear interpolation
+
+    """
+
 def loopSubdivide(
     face: numpy.ndarray[numpy.uint64[m, 3]],
     vertex: numpy.ndarray[numpy.float64[m, 3]],
     nSub: int,
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """loopSubdivide(face: numpy.ndarray[numpy.uint64[m, 3]], vertex: numpy.ndarray[numpy.float64[m, 3]], nSub: int) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+
+    subdivide the mesh in loop scheme
+
+    """
+
 def processSoup(
     meshName: str,
-) -> Tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]: ...
-def startProfiler(filename: str) -> int: ...
-def stopProfiler() -> None: ...
+) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]:
+    """processSoup(meshName: str) -> tuple[numpy.ndarray[numpy.uint64[m, 3]], numpy.ndarray[numpy.float64[m, 3]]]
+
+    process soup data in .ply and return face and vertex matrices.
+
+    """
+
+def startProfiler(filename: str) -> None:
+    """startProfiler(filename: str) -> None
+
+    start profiler
+    """
+
+def stopProfiler() -> None:
+    """stopProfiler() -> None
+
+    stop profiler
+    """

--- a/python_src/pymem3dg/boilerplate.py
+++ b/python_src/pymem3dg/boilerplate.py
@@ -151,6 +151,7 @@ def ambientSolutionOsmoticPressureModel(
 
 
 def prescribeGeodesicProteinDensityDistribution(
+    geometry: dg.Geometry,
     time: float,
     vertexMeanCuravtures: npt.NDArray[np.float64],
     geodesicDistance: npt.NDArray[np.float64],

--- a/python_src/pymem3dg/boilerplate.py
+++ b/python_src/pymem3dg/boilerplate.py
@@ -153,7 +153,7 @@ def ambientSolutionOsmoticPressureModel(
 def prescribeGeodesicProteinDensityDistribution(
     geometry: dg.Geometry,
     time: float,
-    vertexMeanCuravtures: npt.NDArray[np.float64],
+    vertexMeanCurvatures: npt.NDArray[np.float64],
     geodesicDistance: npt.NDArray[np.float64],
     sharpness: float,
     radius: float,

--- a/python_src/pymem3dg/visual.py
+++ b/python_src/pymem3dg/visual.py
@@ -915,6 +915,7 @@ def animate(
     gaussianCurvature: bool = True,
     mechanicalForce: bool = True,
     spontaneousCurvatureForce: bool = True,
+    gaussianCurvatureForce: bool = True,
     deviatoricCurvatureForce: bool = True,
     externalForce: bool = True,
     capillaryForce: bool = True,
@@ -945,6 +946,7 @@ def animate(
         gaussianCurvature (bool, optional): optional data to visualize. Defaults to True
         mechanicalForce (bool, optional): optional data to visualize. Defaults to True
         spontaneousCurvatureForce (bool, optional): optional data to visualize. Defaults to True
+        gaussianCurvatureForce (bool, optional): optional data to visualize. Defaults to True
         deviatoricCurvatureForce (bool, optional): optional data to visualize. Defaults to True
         externalForce (bool, optional): optional data to visualize. Defaults to True
         capillaryForce (bool, optional): optional data to visualize. Defaults to True
@@ -1141,6 +1143,11 @@ def animate(
                 addForce(
                     system.getForces().getSpontaneousCurvatureForceVec(),
                     "spontaneousCurvatureForce",
+                )
+            if gaussianCurvatureForce:
+                addForce(
+                    system.getForces().getGaussianCurvatureForceVec(),
+                    "gaussianCurvatureForce",
                 )
             if deviatoricCurvatureForce:
                 addForce(

--- a/python_src/pymem3dg_forces.cpp
+++ b/python_src/pymem3dg_forces.cpp
@@ -186,6 +186,13 @@ void init_forces(py::module_ &pymem3dg) {
           get the spontaneous curvature potential
       )delim");
   forces.def(
+      "getGaussianCurvatureForceVec",
+      [](Forces &s) { return toMatrix(s.gaussianCurvatureForceVec); },
+      py::return_value_policy::copy,
+      R"delim(
+          get the Gaussian curvature force of the system
+      )delim");
+  forces.def(
       "getDeviatoricCurvaturePotential",
       [](Forces &s) { return s.deviatoricCurvaturePotential.raw(); },
       py::return_value_policy::copy,

--- a/python_src/pymem3dg_geometry.cpp
+++ b/python_src/pymem3dg_geometry.cpp
@@ -127,7 +127,7 @@ void init_geometry(py::module_ &pymem3dg) {
   geometry.def(
       "getVertexMatrix",
       [](Geometry &s) {
-        return gc::EigenMap<double, 3>(s.vpg->inputVertexPositions);
+        return gc::EigenMap<double, 3>(s.vpg->vertexPositions);
       },
       py::return_value_policy::copy,
       R"delim(
@@ -261,13 +261,49 @@ void init_geometry(py::module_ &pymem3dg) {
   /**
    * @brief Methods
    */
-  geometry.def("computeGeodesicDistance", &Geometry::computeGeodesicDistance,
+  geometry.def("computeGeodesicDistance",
+               py::overload_cast<>(&Geometry::computeGeodesicDistance),
                R"delim(
-
           compute the geodesic distance centered around Center cached in System
 
           return: NDarray[double]
       )delim");
+
+  // This version is hard to call since there's not an easy way to create
+  // gcs::Vertex at this point...
+  //   geometry.def("computeGeodesicDistance", py::overload_cast<const
+  //   std::vector<gcs::Vertex>&>(&Geometry::computeGeodesicDistance),
+  //                R"delim(
+
+  //           compute the geodesic distance centered around Center cached in
+  //           System
+
+  //           return: NDarray[double]
+  //       )delim");
+
+  geometry.def("computeGeodesicDistance",
+               py::overload_cast<const std::vector<std::size_t> &>(
+                   &Geometry::computeGeodesicDistance, py::const_),
+               py::arg("points"),
+               R"delim(
+            compute the geodesic distance from a set of vertex indices
+
+            return: NDarray[double]
+        )delim");
+
+  geometry.def(
+      "isBoundary",
+      py::overload_cast<const std::size_t>(&Geometry::isBoundary, py::const_),
+      py::arg("index"),
+      R"delim(
+          check if the vertex is on the boundary
+
+          return: bool
+      )delim");
+
+  geometry.def("nVertices", &Geometry::nVertices);
+  geometry.def("nEdges", &Geometry::nEdges);
+  geometry.def("nFaces", &Geometry::nFaces);
 }
 } // namespace integrator
 } // namespace solver

--- a/python_src/pymem3dg_parameters.cpp
+++ b/python_src/pymem3dg_parameters.cpp
@@ -251,14 +251,9 @@ void init_parameters(py::module_ &pymem3dg) {
   point.def_readwrite("prescribeNotableVertex",
                       &Parameters::Point::prescribeNotableVertex,
                       R"delim(
-        Functional to find the notable vertex of the mesh
+        Getter/setter for function to find the notable vertex of the mesh.
 
-        Args:
-            faceMatrix (npt.NDarray[int64])
-            vertexMatrix (npt.NDarray[float64])
-            geodesicDistance (list)
-        Returns:
-            list[bool]: List of whether each vertex is notable
+        The function should fit the prototype (geometry) -> list[bool]
       )delim");
   point.def_readwrite("updateGeodesicsPeriod",
                       &Parameters::Point::updateGeodesicsPeriod, R"delim(

--- a/python_src/pymem3dg_parameters.cpp
+++ b/python_src/pymem3dg_parameters.cpp
@@ -285,6 +285,7 @@ void init_parameters(py::module_ &pymem3dg) {
       R"delim(
           functional to set the protein density distribution prescription
         args:
+            geometry (Geometry)
             time (float)
             vertexMeanCurvatures (list)
             geodesicDistance (list)

--- a/src/solver/geometry.cpp
+++ b/src/solver/geometry.cpp
@@ -131,20 +131,33 @@ void Geometry::computeFaceTangentialDerivative(
   }
 }
 
+// exists for legacy purposes at this point...
 EigenVectorX1d Geometry::computeGeodesicDistance() {
   // assert(std::count(notableVertex.raw().begin(), notableVertex.raw().end(),
   //                   true) != 0);
-  geodesicDistance.fill(std::numeric_limits<double>::max());
-
-  gcs::HeatMethodDistanceSolver heatSolver(*vpg);
-  // gc::Vertex centerVertex;
+  std::vector<gcs::Vertex> notableVertices;
   for (std::size_t i = 0; i < mesh->nVertices(); ++i) {
     if (notableVertex[i]) {
-      geodesicDistance.raw() = geodesicDistance.raw().cwiseMin(
-          heatSolver.computeDistance(mesh->vertex(i)).raw());
+      notableVertices.emplace_back(mesh->vertex(i));
     }
   }
+  geodesicDistance.raw() = computeGeodesicDistance(notableVertices);
   return geodesicDistance.raw();
+}
+
+EigenVectorX1d Geometry::computeGeodesicDistance(
+    const std::vector<gcs::Vertex> &points) const {
+  gcs::HeatMethodDistanceSolver heatSolver(*vpg);
+  return heatSolver.computeDistance(points).raw();
+}
+
+EigenVectorX1d Geometry::computeGeodesicDistance(
+    const std::vector<std::size_t> &points) const {
+  std::vector<gcs::Vertex> output;
+  std::transform(points.begin(), points.end(), std::back_inserter(output),
+                 [this](int value) { return mesh->vertex(value); });
+
+  return computeGeodesicDistance(output);
 }
 
 void Geometry::updateReferenceConfigurations() {

--- a/src/solver/init.cpp
+++ b/src/solver/init.cpp
@@ -210,7 +210,7 @@ bool System::updatePrescription(bool &ifMutateMesh, bool &ifUpdateNotableVertex,
     if (parameters.protein.prescribeProteinDensityDistribution != NULL) {
       proteinDensity.raw() =
           parameters.protein.prescribeProteinDensityDistribution(
-              time, geometry.vpg->vertexMeanCurvatures.raw(),
+              geometry, time, geometry.vpg->vertexMeanCurvatures.raw(),
               geometry.geodesicDistance.raw());
       updateConfigurations();
     } else {

--- a/src/solver/init.cpp
+++ b/src/solver/init.cpp
@@ -145,19 +145,17 @@ void System::updateConfigurations() {
 bool System::updatePrescription(std::map<std::string, double> &lastUpdateTime,
                                 double timeStep) {
   bool ifMutateMesh = (time - lastUpdateTime["mutateMesh"] >
-                       (meshProcessor.meshMutator.mutateMeshPeriod * timeStep)),
-       ifUpdateNotableVertex =
-           (time - lastUpdateTime["notableVertex"] >
-            (parameters.point.updateNotableVertexPeriod * timeStep)),
-       ifUpdateGeodesics =
-           (time - lastUpdateTime["geodesics"] >
-            (parameters.point.updateGeodesicsPeriod * timeStep)),
+                       (meshProcessor.meshMutator.mutateMeshPeriod)),
+       ifUpdateNotableVertex = (time - lastUpdateTime["notableVertex"] >
+                                (parameters.point.updateNotableVertexPeriod)),
+       ifUpdateGeodesics = (time - lastUpdateTime["geodesics"] >
+                            (parameters.point.updateGeodesicsPeriod)),
        ifUpdateProteinDensityDistribution =
            (time - lastUpdateTime["protein"] >
             (parameters.protein.updateProteinDensityDistributionPeriod *
              timeStep)),
        ifUpdateMask = (time - lastUpdateTime["mask"] >
-                       (parameters.variation.updateMaskPeriod * timeStep));
+                       (parameters.variation.updateMaskPeriod));
 
   bool updated =
       updatePrescription(ifMutateMesh, ifUpdateNotableVertex, ifUpdateGeodesics,

--- a/src/solver/init.cpp
+++ b/src/solver/init.cpp
@@ -145,17 +145,16 @@ void System::updateConfigurations() {
 bool System::updatePrescription(std::map<std::string, double> &lastUpdateTime,
                                 double timeStep) {
   bool ifMutateMesh = (time - lastUpdateTime["mutateMesh"] >
-                       (meshProcessor.meshMutator.mutateMeshPeriod)),
+                       meshProcessor.meshMutator.mutateMeshPeriod),
        ifUpdateNotableVertex = (time - lastUpdateTime["notableVertex"] >
-                                (parameters.point.updateNotableVertexPeriod)),
+                                parameters.point.updateNotableVertexPeriod),
        ifUpdateGeodesics = (time - lastUpdateTime["geodesics"] >
-                            (parameters.point.updateGeodesicsPeriod)),
+                            parameters.point.updateGeodesicsPeriod),
        ifUpdateProteinDensityDistribution =
            (time - lastUpdateTime["protein"] >
-            (parameters.protein.updateProteinDensityDistributionPeriod *
-             timeStep)),
+            parameters.protein.updateProteinDensityDistributionPeriod),
        ifUpdateMask = (time - lastUpdateTime["mask"] >
-                       (parameters.variation.updateMaskPeriod));
+                       parameters.variation.updateMaskPeriod);
 
   bool updated =
       updatePrescription(ifMutateMesh, ifUpdateNotableVertex, ifUpdateGeodesics,

--- a/src/solver/init.cpp
+++ b/src/solver/init.cpp
@@ -195,10 +195,8 @@ bool System::updatePrescription(bool &ifMutateMesh, bool &ifUpdateNotableVertex,
 
   if (ifUpdateNotableVertex) {
     if (parameters.point.prescribeNotableVertex != NULL) {
-      geometry.notableVertex.raw() = parameters.point.prescribeNotableVertex(
-          geometry.mesh->getFaceVertexMatrix<std::size_t>(),
-          toMatrix(geometry.vpg->vertexPositions),
-          geometry.geodesicDistance.raw());
+      geometry.notableVertex.raw() =
+          parameters.point.prescribeNotableVertex(geometry);
     } else {
       ifUpdateNotableVertex = false;
       // mem3dg_runtime_warning("Parameter.point.prescribeNotableVertex is

--- a/src/solver/integrator/conjugate_gradient.cpp
+++ b/src/solver/integrator/conjugate_gradient.cpp
@@ -80,7 +80,7 @@ bool ConjugateGradient::integrate() {
     }
 
     // step forward
-    if (system.updatePrescription(lastUpdateTime, timeStep)) {
+    if (system.updatePrescription(lastUpdateTime, baseTimeStep)) {
       system.time += 1e-5 * timeStep;
       countCG = 0;
     } else {

--- a/src/solver/integrator/forward_euler.cpp
+++ b/src/solver/integrator/forward_euler.cpp
@@ -237,6 +237,9 @@ void Euler::march() {
     characteristicTimeStep = getAdaptiveCharacteristicTimeStep();
   }
 
+
+
+
   // backtracking to obtain stable time step
   if (isBacktrack) {
     double timeStep_mech = std::numeric_limits<double>::max(),
@@ -249,9 +252,24 @@ void Euler::march() {
   } else {
     timeStep = characteristicTimeStep;
   }
-  system.geometry.vpg->inputVertexPositions += system.velocity * timeStep;
+
+  // // march the system with increment time step obtained above
+  // double hdt = timeStep;
+
+  // // stepping on vertex position
+  // system.geometry.vpg->inputVertexPositions +=
+  //     system.velocity * timeStep +
+  //     hdt * pastMechanicalForceVec; 
+  // system.geometry.vpg->inputVertexPositions += system.velocity * timeStep;
+  // system.geometry.vpg->inputVertexPositions += (system.velocity+2*pastMechanicalForceVec+past2MechanicalForceVec) * timeStep/2;
+  system.geometry.vpg->inputVertexPositions += (system.velocity+pastMechanicalForceVec) * timeStep/2;
   system.proteinDensity += system.proteinRateOfChange * timeStep;
   system.time += timeStep;
+
+  // past2MechanicalForceVec = pastMechanicalForceVec;
+
+  pastMechanicalForceVec = system.forces.mechanicalForceVec;
+
 
   // recompute cached values
   system.updateConfigurations();

--- a/src/solver/integrator/forward_euler.cpp
+++ b/src/solver/integrator/forward_euler.cpp
@@ -100,11 +100,9 @@ bool Euler::integrate() {
       break;
     }
 
-    if (system.updatePrescription(lastUpdateTime, timeStep)) {
-      system.time += 1e-5 * timeStep;
-    } else {
-      march();
-    }
+    // Mutate mesh, update notable vertex, geodesics, protein density, and mask
+    system.updatePrescription(lastUpdateTime, baseTimeStep);
+    march();
   }
 
 #ifdef MEM3DG_WITH_NETCDF

--- a/src/solver/integrator/forward_euler.cpp
+++ b/src/solver/integrator/forward_euler.cpp
@@ -88,21 +88,24 @@ bool Euler::integrate() {
     // Evaluate and threshold status data
     status();
 
+    mem3dg_print_noendl("TIME: ", system.time, " dt:", timeStep, "\r");
     // Save files every tSave period and print some info; save data before exit
     if (system.time - lastSave >= savePeriod || system.time == initialTime ||
         EXIT) {
       lastSave = system.time;
       saveData(ifOutputTrajFile, ifOutputMeshFile, ifPrintToConsole);
     }
-
     // break loop if EXIT flag is on
     if (EXIT) {
       break;
     }
 
     // Mutate mesh, update notable vertex, geodesics, protein density, and mask
-    system.updatePrescription(lastUpdateTime, baseTimeStep);
-    march();
+    if (system.updatePrescription(lastUpdateTime, baseTimeStep)) {
+      system.time += 1e-5 * timeStep;
+    } else {
+      march();
+    }
   }
 
 #ifdef MEM3DG_WITH_NETCDF
@@ -145,7 +148,7 @@ void Euler::status() {
   // exit if under error tolerance
   if (system.mechErrorNorm < tolerance && system.chemErrorNorm < tolerance) {
     if (ifPrintToConsole)
-      std::cout << "\nError norm smaller than tolerance." << std::endl;
+      mem3dg_print("Error norm smaller than tolerance.");
     EXIT = true;
   }
 

--- a/src/solver/integrator/forward_euler.cpp
+++ b/src/solver/integrator/forward_euler.cpp
@@ -237,9 +237,6 @@ void Euler::march() {
     characteristicTimeStep = getAdaptiveCharacteristicTimeStep();
   }
 
-
-
-
   // backtracking to obtain stable time step
   if (isBacktrack) {
     double timeStep_mech = std::numeric_limits<double>::max(),
@@ -252,24 +249,9 @@ void Euler::march() {
   } else {
     timeStep = characteristicTimeStep;
   }
-
-  // // march the system with increment time step obtained above
-  // double hdt = timeStep;
-
-  // // stepping on vertex position
-  // system.geometry.vpg->inputVertexPositions +=
-  //     system.velocity * timeStep +
-  //     hdt * pastMechanicalForceVec; 
-  // system.geometry.vpg->inputVertexPositions += system.velocity * timeStep;
-  // system.geometry.vpg->inputVertexPositions += (system.velocity+2*pastMechanicalForceVec+past2MechanicalForceVec) * timeStep/2;
-  system.geometry.vpg->inputVertexPositions += (system.velocity+pastMechanicalForceVec) * timeStep/2;
+  system.geometry.vpg->inputVertexPositions += system.velocity * timeStep;
   system.proteinDensity += system.proteinRateOfChange * timeStep;
   system.time += timeStep;
-
-  // past2MechanicalForceVec = pastMechanicalForceVec;
-
-  pastMechanicalForceVec = system.forces.mechanicalForceVec;
-
 
   // recompute cached values
   system.updateConfigurations();

--- a/src/solver/integrator/integrator.cpp
+++ b/src/solver/integrator/integrator.cpp
@@ -37,20 +37,22 @@ double Integrator::getAdaptiveCharacteristicTimeStep() {
           ? system.forces.mechanicalForce.raw().cwiseAbs().maxCoeff()
           : system.forces.chemicalPotential.raw().cwiseAbs().maxCoeff();
 
-  double dt = (dt_size2_ratio * currentMinimumSize * currentMinimumSize) *
-              (initialMaximumForce / currentMaximumForce);
+  // double dt = (dt_size2_ratio * currentMinimumSize * currentMinimumSize) *
+  //             (initialMaximumForce / currentMaximumForce);
+  double dt = (dt_size2_ratio * currentMinimumSize) *
+            (initialMaximumForce / currentMaximumForce);
 
-  if (characteristicTimeStep / dt > 1e3) {
-    mem3dg_runtime_warning(
-        "Adaptive time step has become too small!",
-        "Consider restarting simulation in smaller timestep.",
-        "Current size / initial size =",
-        currentMinimumSize / pow(characteristicTimeStep / dt_size2_ratio, 0.5),
-        "Current force / initial force =",
-        currentMaximumForce / initialMaximumForce);
-    EXIT = true;
-    SUCCESS = false;
-  }
+  // if (characteristicTimeStep / dt > 1e3) {
+  //   mem3dg_runtime_warning(
+  //       "Adaptive time step has become too small!",
+  //       "Consider restarting simulation in smaller timestep.",
+  //       "Current size / initial size =",
+  //       currentMinimumSize / pow(characteristicTimeStep / dt_size2_ratio, 0.5),
+  //       "Current force / initial force =",
+  //       currentMaximumForce / initialMaximumForce);
+  //   EXIT = true;
+  //   SUCCESS = false;
+  // }
   return dt;
 }
 

--- a/src/solver/integrator/integrator.cpp
+++ b/src/solver/integrator/integrator.cpp
@@ -404,7 +404,9 @@ void Integrator::saveData(bool outputTrajFile, bool outputMeshFile,
                .sum()
         << "\n"
         << "H0: [" << system.H0.raw().minCoeff() << ","
-        << system.H0.raw().maxCoeff() << "]" << std::endl;
+        << system.H0.raw().maxCoeff() << "]"
+        << "\n"
+        << "timestep: " << timeStep << std::endl;
 
     // report the backtracking if verbose
     if (timeStep != characteristicTimeStep && printToConsole) {

--- a/src/solver/integrator/integrator.cpp
+++ b/src/solver/integrator/integrator.cpp
@@ -37,22 +37,20 @@ double Integrator::getAdaptiveCharacteristicTimeStep() {
           ? system.forces.mechanicalForce.raw().cwiseAbs().maxCoeff()
           : system.forces.chemicalPotential.raw().cwiseAbs().maxCoeff();
 
-  // double dt = (dt_size2_ratio * currentMinimumSize * currentMinimumSize) *
-  //             (initialMaximumForce / currentMaximumForce);
-  double dt = (dt_size2_ratio * currentMinimumSize) *
-            (initialMaximumForce / currentMaximumForce);
+  double dt = (dt_size2_ratio * currentMinimumSize * currentMinimumSize) *
+              (initialMaximumForce / currentMaximumForce);
 
-  // if (characteristicTimeStep / dt > 1e3) {
-  //   mem3dg_runtime_warning(
-  //       "Adaptive time step has become too small!",
-  //       "Consider restarting simulation in smaller timestep.",
-  //       "Current size / initial size =",
-  //       currentMinimumSize / pow(characteristicTimeStep / dt_size2_ratio, 0.5),
-  //       "Current force / initial force =",
-  //       currentMaximumForce / initialMaximumForce);
-  //   EXIT = true;
-  //   SUCCESS = false;
-  // }
+  if (characteristicTimeStep / dt > 1e3) {
+    mem3dg_runtime_warning(
+        "Adaptive time step has become too small!",
+        "Consider restarting simulation in smaller timestep.",
+        "Current size / initial size =",
+        currentMinimumSize / pow(characteristicTimeStep / dt_size2_ratio, 0.5),
+        "Current force / initial force =",
+        currentMaximumForce / initialMaximumForce);
+    EXIT = true;
+    SUCCESS = false;
+  }
   return dt;
 }
 

--- a/src/solver/integrator/velocity_verlet.cpp
+++ b/src/solver/integrator/velocity_verlet.cpp
@@ -83,7 +83,7 @@ bool VelocityVerlet::integrate() {
     }
 
     // step forward
-    if (system.updatePrescription(lastUpdateTime, timeStep)) {
+    if (system.updatePrescription(lastUpdateTime, baseTimeStep)) {
       system.time += 1e-5 * timeStep;
     } else {
       march();

--- a/src/solver/mesh_process.cpp
+++ b/src/solver/mesh_process.cpp
@@ -152,7 +152,7 @@ bool MeshProcessor::MeshMutator::checkSplitCondition(
   bool is2Large = false;
   bool is2Long = false;
   bool is2Curved = false;
-  // bool is2Sharp = false;
+  bool is2Sharp = false;
   bool is2Fat = false;
   bool is2Skinny = false;
   bool isDelaunay = false;
@@ -184,7 +184,10 @@ bool MeshProcessor::MeshMutator::checkSplitCondition(
   }
 
   if (splitSharp) {
-    mem3dg_runtime_error("Split sharp is currently not supported");
+    // mem3dg_runtime_error("Split sharp is currently not supported");
+    std::size_t i_vj = he.tipVertex().getIndex();
+    is2Sharp = vpg.vertexMeanCurvatures[i_vj]> 10;//splitCurvedScaleFactor;
+    condition = is2Sharp || condition;
     // is2Sharp = abs(H0[he.tipVertex()] - H0[he.tailVertex()]) > (2 *
     // targetdH0);
   }

--- a/src/solver/mesh_process.cpp
+++ b/src/solver/mesh_process.cpp
@@ -152,7 +152,7 @@ bool MeshProcessor::MeshMutator::checkSplitCondition(
   bool is2Large = false;
   bool is2Long = false;
   bool is2Curved = false;
-  bool is2Sharp = false;
+  // bool is2Sharp = false;
   bool is2Fat = false;
   bool is2Skinny = false;
   bool isDelaunay = false;
@@ -184,10 +184,7 @@ bool MeshProcessor::MeshMutator::checkSplitCondition(
   }
 
   if (splitSharp) {
-    // mem3dg_runtime_error("Split sharp is currently not supported");
-    std::size_t i_vj = he.tipVertex().getIndex();
-    is2Sharp = vpg.vertexMeanCurvatures[i_vj]> 10;//splitCurvedScaleFactor;
-    condition = is2Sharp || condition;
+    mem3dg_runtime_error("Split sharp is currently not supported");
     // is2Sharp = abs(H0[he.tipVertex()] - H0[he.tailVertex()]) > (2 *
     // targetdH0);
   }

--- a/src/solver/misc.cpp
+++ b/src/solver/misc.cpp
@@ -188,7 +188,7 @@ bool System::testConservativeForcing(const double timeStep) {
 
   // lambda function to test mechanical forces
   auto testMechanical = [previousProteinDensity, previousPosition, timeStep,
-                         this](gcs::VertexData<gc::Vector3> &forceVec,
+                         this](const gcs::VertexData<gc::Vector3> &forceVec,
                                const double &previousEnergy,
                                const double &currentEnergy,
                                std::string forceKey,

--- a/src/solver/regularization.cpp
+++ b/src/solver/regularization.cpp
@@ -129,8 +129,8 @@ void System::mutateMesh(size_t nRepetition) {
 
 void System::vertexShift() {
   for (gcs::Vertex v : geometry.mesh->vertices()) {
-    // Only move if not significantly force masked
-    if (gc::sum(forces.forceMask[v]) > 0.5) {
+    // Only move if not significantly force masked nor notable
+    if (gc::sum(forces.forceMask[v]) > 0.5 && !geometry.notableVertex[v]) {
       if (v.isBoundary()) {
         gc::Vector3 barycenter{0.0, 0.0, 0.0};
         std::vector<gcs::Vertex> adjacent_boundary_vertices;
@@ -314,6 +314,9 @@ bool System::processSplitCollapse() {
     gc::Vector3 vertex2ForceMask = forces.forceMask[vertex2];
     // don't keep processing static vertices
     if (gc::sum(vertex1ForceMask + vertex2ForceMask) <= maskThreshold)
+      continue;
+
+    if (geometry.notableVertex[vertex1] || geometry.notableVertex[vertex2])
       continue;
 
     // Splitting

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,11 +15,14 @@
 
 include(FetchContent)
 
+set(BUILD_SHARED_LIBS_SAVED "${BUILD_SHARED_LIBS}")
+set(BUILD_SHARED_LIBS OFF)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest.git
   GIT_TAG origin/main
   GIT_SHALLOW TRUE
+  EXCLUDE_FROM_ALL SYSTEM
 )
 # Prevent overriding the parent project's compiler/linker settings on Windows
 set(gtest_force_shared_crt
@@ -27,15 +30,8 @@ set(gtest_force_shared_crt
     CACHE BOOL "" FORCE
 )
 
-FetchContent_GetProperties(googletest)
-if(NOT googletest_POPULATED)
-  FetchContent_Populate(googletest)
-endif()
-add_subdirectory(
-  ${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} SYSTEM EXCLUDE_FROM_ALL
-)
-
-# FetchContent_MakeAvailable(googletest)
+FetchContent_MakeAvailable(googletest)
+set(BUILD_SHARED_LIBS "${BUILD_SHARED_LIBS_SAVED}")
 
 # Build the tests
 set(MEM3DG_TEST_SRCS src/main_test.cpp src/product_test.cpp src/force_test.cpp

--- a/tests/src/force_test.cpp
+++ b/tests/src/force_test.cpp
@@ -64,7 +64,8 @@ protected:
     p.variation.isProteinVariation = true;
     p.variation.geodesicMask = -1;
 
-    auto geodesicProteinDensity = [](double time, EigenVectorX1d meanCurvature,
+    auto geodesicProteinDensity = [](const Geometry &g, double time,
+                                     EigenVectorX1d meanCurvature,
                                      EigenVectorX1d geodesicDistance) {
       EigenVectorX1d proteinDensity;
       proteinDensity.resize(geodesicDistance.rows(), 1);


### PR DESCRIPTION
## Description
Mesh mutation and property prescription algorithms are set as a function of numbers of time steps. Variable time step setting algorithms change the simulation time step as a function of the stiffness of the configuration. Since the next update times were set as a function of the current time step it led to irregular frequencies of update.

This PR adds a baseTimeStep which keeps track of the user intended step relative to which the mutation/prescription periods should be set.

## Todos
 - [x] Respect the original frequencies of mesh mutation
 - [x] Add a stricter restriction for split/collapse around masked elements
 - [x] Adds a generalized geodesic distance function 

## Status
- [x] Ready to go
